### PR TITLE
Simplify combine* methods

### DIFF
--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -16,7 +16,6 @@
 package com.spotify.futures;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -198,24 +197,38 @@ public final class CompletableFutures {
   public static <R, A, B, C> CompletionStage<R> combine3(
       CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
       Function3<R, A, B, C> function) {
-    return allAsList(Arrays.asList(a, b, c))
-        .thenApply(list -> function.apply((A) list.get(0), (B) list.get(1), (C) list.get(2)));
+    final CompletableFuture<A> af = a.toCompletableFuture();
+    final CompletableFuture<B> bf = b.toCompletableFuture();
+    final CompletableFuture<C> cf = c.toCompletableFuture();
+
+    return CompletableFuture.allOf(af, bf, cf)
+        .thenApply(ignored -> function.apply(af.join(), bf.join(), cf.join()));
   }
 
   public static <R, A, B, C, D> CompletionStage<R> combine4(
       CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c, CompletionStage<D> d,
       Function4<R, A, B, C, D> function) {
-    return allAsList(Arrays.asList(a, b, c, d))
-        .thenApply(list -> function.apply(
-            (A) list.get(0), (B) list.get(1), (C) list.get(2), (D) list.get(3)));
+    final CompletableFuture<A> af = a.toCompletableFuture();
+    final CompletableFuture<B> bf = b.toCompletableFuture();
+    final CompletableFuture<C> cf = c.toCompletableFuture();
+    final CompletableFuture<D> df = d.toCompletableFuture();
+
+    return CompletableFuture.allOf(af, bf, cf)
+        .thenApply(ignored -> function.apply(af.join(), bf.join(), cf.join(), df.join()));
   }
 
   public static <R, A, B, C, D, E> CompletionStage<R> combine5(
       CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
       CompletionStage<D> d, CompletionStage<E> e,
       Function5<R, A, B, C, D, E> function) {
-    return allAsList(Arrays.asList(a, b, c, d, e))
-        .thenApply(list -> function.apply(
-            (A) list.get(0), (B) list.get(1), (C) list.get(2), (D) list.get(3), (E) list.get(4)));
+    final CompletableFuture<A> af = a.toCompletableFuture();
+    final CompletableFuture<B> bf = b.toCompletableFuture();
+    final CompletableFuture<C> cf = c.toCompletableFuture();
+    final CompletableFuture<D> df = d.toCompletableFuture();
+    final CompletableFuture<E> ef = e.toCompletableFuture();
+
+    return CompletableFuture.allOf(af, bf, cf)
+        .thenApply(ignored ->
+                       function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join()));
   }
 }


### PR DESCRIPTION
Instead of getting `N` stages, (1) wrapping them into an array (`Arrays.asList` varargs), (2) wrapping the array in a list, then (3) converting the list back into an array, and then calling `CompletableFuture.allOf` on the array, to then (4) put the join results into a list, that is then immediately deconstructed, we can do all of this by just allocating a single varargs array, and we avoid unsafe casts and arguably make the code clearer.
