### PR TITLE
Add combine2 for completeness

### DIFF
--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -194,6 +194,12 @@ public final class CompletableFutures {
     return future.thenApply(CompletableFuture::completedFuture);
   }
 
+  public static <R, A, B> CompletionStage<R> combine2(
+      CompletionStage<A> a, CompletionStage<B> b,
+      BiFunction<A, B, R> function) {
+    return a.thenCombine(b, function);
+  }
+
   public static <R, A, B, C> CompletionStage<R> combine3(
       CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
       Function3<A, B, C, R> function) {


### PR DESCRIPTION
Diffs in application code arguably become easier to read if they are like:

``` diff
-combine3(a, b, c, ...)
+combine2(a, b, ...)
```
