### PR TITLE
Change Function* signature to match java.util.function

### DIFF
--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -196,7 +196,7 @@ public final class CompletableFutures {
 
   public static <R, A, B, C> CompletionStage<R> combine3(
       CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
-      Function3<R, A, B, C> function) {
+      Function3<A, B, C, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
     final CompletableFuture<C> cf = c.toCompletableFuture();
@@ -207,7 +207,7 @@ public final class CompletableFutures {
 
   public static <R, A, B, C, D> CompletionStage<R> combine4(
       CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c, CompletionStage<D> d,
-      Function4<R, A, B, C, D> function) {
+      Function4<A, B, C, D, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
     final CompletableFuture<C> cf = c.toCompletableFuture();
@@ -220,7 +220,7 @@ public final class CompletableFutures {
   public static <R, A, B, C, D, E> CompletionStage<R> combine5(
       CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
       CompletionStage<D> d, CompletionStage<E> e,
-      Function5<R, A, B, C, D, E> function) {
+      Function5<A, B, C, D, E, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
     final CompletableFuture<C> cf = c.toCompletableFuture();

--- a/src/main/java/com/spotify/futures/Function3.java
+++ b/src/main/java/com/spotify/futures/Function3.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
  * @see Function
  */
 @FunctionalInterface
-public interface Function3<R, A, B, C> {
+public interface Function3<A, B, C, R> {
 
     /**
      * Applies this function to the given arguments.
@@ -58,7 +58,7 @@ public interface Function3<R, A, B, C> {
      * applies the {@code after} function
      * @throws NullPointerException if after is null
      */
-    default <V> Function3<V, A, B, C> andThen(Function<? super R, ? extends V> after) {
+    default <V> Function3<A, B, C, V> andThen(Function<? super R, ? extends V> after) {
         Objects.requireNonNull(after);
         return (A a, B b, C c) -> after.apply(apply(a, b, c));
     }

--- a/src/main/java/com/spotify/futures/Function4.java
+++ b/src/main/java/com/spotify/futures/Function4.java
@@ -34,7 +34,7 @@ import java.util.function.Function;
  * @see Function
  */
 @FunctionalInterface
-public interface Function4<R, A, B, C, D> {
+public interface Function4<A, B, C, D, R> {
 
     /**
      * Applies this function to the given arguments.
@@ -60,7 +60,7 @@ public interface Function4<R, A, B, C, D> {
      * applies the {@code after} function
      * @throws NullPointerException if after is null
      */
-    default <V> Function4<V, A, B, C, D> andThen(Function<? super R, ? extends V> after) {
+    default <V> Function4<A, B, C, D, V> andThen(Function<? super R, ? extends V> after) {
         Objects.requireNonNull(after);
         return (A a, B b, C c, D d) -> after.apply(apply(a, b, c, d));
     }

--- a/src/main/java/com/spotify/futures/Function5.java
+++ b/src/main/java/com/spotify/futures/Function5.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
  * @see Function
  */
 @FunctionalInterface
-public interface Function5<R, A, B, C, D, E> {
+public interface Function5<A, B, C, D, E, R> {
 
     /**
      * Applies this function to the given arguments.
@@ -62,7 +62,7 @@ public interface Function5<R, A, B, C, D, E> {
      * applies the {@code after} function
      * @throws NullPointerException if after is null
      */
-    default <V> Function5<V, A, B, C, D, E> andThen(Function<? super R, ? extends V> after) {
+    default <V> Function5<A, B, C, D, E, V> andThen(Function<? super R, ? extends V> after) {
         Objects.requireNonNull(after);
         return (A a, B b, C c, D d, E e) -> after.apply(apply(a, b, c, d, e));
     }


### PR DESCRIPTION
In `java.util.function`, the result type comes last in the type signature, so if some code goes from using `BiFunction` to `Function3`, the diff will be easier to read.
