### PR TITLE
fix(compose): Prevent thread blocks by waiting on all futures

### DIFF
--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -219,7 +219,7 @@ public final class CompletableFutures {
     final CompletableFuture<C> cf = c.toCompletableFuture();
     final CompletableFuture<D> df = d.toCompletableFuture();
 
-    return CompletableFuture.allOf(af, bf, cf)
+    return CompletableFuture.allOf(af, bf, cf, df)
         .thenApply(ignored -> function.apply(af.join(), bf.join(), cf.join(), df.join()));
   }
 
@@ -233,7 +233,7 @@ public final class CompletableFutures {
     final CompletableFuture<D> df = d.toCompletableFuture();
     final CompletableFuture<E> ef = e.toCompletableFuture();
 
-    return CompletableFuture.allOf(af, bf, cf)
+    return CompletableFuture.allOf(af, bf, cf, df, ef)
         .thenApply(ignored ->
                        function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join()));
   }

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -409,6 +409,16 @@ public class CompletableFuturesTest {
   }
 
   @Test
+  public void combine4_incomplete() throws Exception {
+    final CompletionStage<String> future = combine(
+        completedFuture("a"), completedFuture("b"), completedFuture("c"),
+        incompleteFuture(),
+            (a, b, c, d) -> a + b + c + d);
+    exception.expect(isA(IllegalStateException.class));
+    getCompleted(future);
+  }
+
+  @Test
   public void combine5_completed() throws Exception {
     final CompletionStage<String> future = combine(
         completedFuture("a"), completedFuture("b"), completedFuture("c"),
@@ -428,5 +438,20 @@ public class CompletableFuturesTest {
 
     exception.expectCause(isA(IllegalStateException.class));
     getCompleted(future);
+  }
+
+  @Test
+  public void combine5_incomplete() throws Exception {
+    final CompletionStage<String> future = combine(
+        completedFuture("a"), completedFuture("b"), completedFuture("c"),
+        completedFuture("d"),
+        incompleteFuture(),
+            (a, b, c, d, e) -> a + b + c + d + e);
+    exception.expect(isA(IllegalStateException.class));
+    getCompleted(future);
+  }
+
+  private static <T> CompletableFuture<T> incompleteFuture() {
+    return new CompletableFuture<>();
   }
 }


### PR DESCRIPTION
The tests expose that the thread will block indefinitely on an incomplete
future for order-4 and order-5 composes.  The fix is to call `allOf` on all
provided futures.