### PR TITLE
Add CompletableFutures.successfulAsList

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ List<CompletableFuture<String>> futures = asList(completedFuture("a"), completed
 CompletableFuture<List<String>> joined = CompletableFutures.allAsList(futures);
 ```
 
+#### successfulAsList
+
+Works like `allAsList`, but futures that fail will not fail the joined future. Instead, the
+defaultValueMapper function will be called once for each failed future and value returned will be
+put in the resulting list on the place corresponding to the failed future. The default value
+returned by the function may be anything, such as `null` or `Optional.empty()`.
+
+```java
+List<CompletableFuture<String>> input = asList(
+    completedFuture("a"),
+    exceptionallyCompletedFuture(new RuntimeException("boom")));
+CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(input, t -> "default");
+```
+
 #### joinList
 
 `joinList` is a stream collector that combines multiple futures into a list. This is handy if you

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -82,6 +82,30 @@ public final class CompletableFutures {
   }
 
   /**
+   * Returns a new {@link CompletableFuture} which completes to a list of values of those input
+   * stages that succeeded. The list of results is in the same order as the input stages. For failed
+   * stages, the defaultValueMapper will be called, and the value returned from that function will
+   * be put in the resulting list.
+   *
+   * <p>If no stages are provided, returns a future holding an empty list.
+   *
+   * @param stages the stages to combine.
+   * @param defaultValueMapper a function that will be called when a future completes exceptionally
+   * to provide a default value to place in the resulting list
+   * @param <T>    the common type of all of the input stages, that determines the type of the
+   *               output future
+   * @return a future that completes to a list of the results of the supplied stages
+   * @throws NullPointerException if the stages list or any of its elements are {@code null}
+   */
+  public static <T> CompletableFuture<List<T>> successfulAsList(
+      List<? extends CompletionStage<T>> stages,
+      Function<Throwable, ? extends T> defaultValueMapper) {
+    return stages.stream()
+        .map(f -> f.exceptionally(defaultValueMapper))
+        .collect(joinList());
+  }
+
+  /**
    * Returns a new {@code CompletableFuture} that is already exceptionally completed with
    * the given exception.
    *

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -44,6 +44,7 @@ import static com.spotify.futures.CompletableFutures.getCompleted;
 import static com.spotify.futures.CompletableFutures.handleCompose;
 import static com.spotify.futures.CompletableFutures.joinList;
 import static com.spotify.futures.CompletableFutures.poll;
+import static com.spotify.futures.CompletableFutures.successfulAsList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -130,6 +131,18 @@ public class CompletableFuturesTest {
 
     exception.expect(NullPointerException.class);
     allAsList(input);
+  }
+
+  @Test
+  public void successfulAsList_exceptionalAndNull() throws Exception {
+    final List<CompletableFuture<String>> input = asList(
+        completedFuture("a"),
+        exceptionallyCompletedFuture(new RuntimeException("boom")),
+        completedFuture(null),
+        completedFuture("d")
+    );
+    final List<String> expected = asList("a", "default", null, "d");
+    assertThat(successfulAsList(input, t -> "default"), completesTo(expected));
   }
 
   @Test


### PR DESCRIPTION
When migrating from guava ListenableFuture, we missed the Futures.successfulAsList. This implements the same functionality for CompletableFutures.