### PR TITLE
Add CompletableFutures.poll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ CompletableFutures.combine(f1, f2, f3, f4, (a, b, c, d) -> a + b + c + d);
 CompletableFutures.combine(f1, f2, f3, f4, f5, (a, b, c, d, e) -> a + b + c + d + e);
 ```
 
+### Scheduling
+
+#### Polling an external resource
+
+If you are dealing with a long-running external task that only exposes a polling API, you can
+transform that into a future like so:
+
+```java
+ExternalResource<T> resource = ...
+CompletableFuture<T> result = CompletableFutures.poll(resource::optionalResult, 2, SECONDS, executor);
+```
+
 ### Missing parts of the CompletableFuture API
 
 The `CompletableFutures` class includes utility functions for operating on futures that is missing

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ If you are dealing with a long-running external task that only exposes a polling
 transform that into a future like so:
 
 ```java
-ExternalResource<T> resource = ...
-CompletableFuture<T> result = CompletableFutures.poll(resource::optionalResult, 2, SECONDS, executor);
+Supplier<Optional<T>> pollingTask = () -> Optional.ofNullable(resource.result());
+Duration frequency = Duration.ofSeconds(2);
+CompletableFuture<T> result = CompletableFutures.poll(pollingTask, frequency, executor);
 ```
 
 ### Missing parts of the CompletableFuture API

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock</artifactId>
+      <version>2.8.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
       <version>1.11.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -142,7 +142,7 @@ public final class CompletableFutures {
    * {@code null} if none) of this stage as arguments, and the
    * function's result is used to complete the returned stage.
    *
-   * This differs from
+   * <p>This differs from
    * {@link java.util.concurrent.CompletionStage#handle(java.util.function.BiFunction)}
    * in that the function should return a {@link java.util.concurrent.CompletionStage} rather than
    * the value directly.
@@ -166,7 +166,7 @@ public final class CompletableFutures {
    * completes normally, then the returned stage also completes
    * normally with the same value.
    *
-   * This differs from
+   * <p>This differs from
    * {@link java.util.concurrent.CompletionStage#exceptionally(java.util.function.Function)}
    * in that the function should return a {@link java.util.concurrent.CompletionStage} rather than
    * the value directly.
@@ -184,8 +184,7 @@ public final class CompletableFutures {
   }
 
   /**
-   * This takes a stage of a stage of a value and
-   * returns a plain stage of a value.
+   * This takes a stage of a stage of a value and returns a plain stage of a value.
    *
    * @param stage a {@link CompletionStage} of a {@link CompletionStage} of a value
    * @return the {@link CompletionStage} of the value
@@ -247,11 +246,16 @@ public final class CompletableFutures {
   /**
    * Periodically poll an external resource until it returns a non-empty result.
    *
-   * The polling task should return Optional.empty() until it becomes available, and then
-   * Optional.of(result).
+   * <p>The polling task should return Optional.empty() until it becomes available, and then
+   * Optional.of(result). If the polling task throws an exception or returns null, that will cause
+   * the result future to complete exceptionally.
    *
-   * If the polling task throws an exception or returns null, that will cause the result future to
-   * complete exceptionally.
+   * <p>Canceling the returned future will cancel the scheduled polling task as well.
+   *
+   * <p>Note that on a ScheduledThreadPoolExecutor the polling task might remain allocated for up
+   * to 'frequency' time after completing or being cancelled. If you have lots of polling operations
+   * or a long polling frequency, consider setting removeOnCancelPolicy to true.
+   * See {@link java.util.concurrent.ScheduledThreadPoolExecutor#setRemoveOnCancelPolicy(boolean)}.
    *
    * @param pollingTask the polling task.
    * @param frequency the frequency to run the polling task at.

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -15,6 +15,7 @@
  */
 package com.spotify.futures;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -253,18 +254,17 @@ public final class CompletableFutures {
    * complete exceptionally.
    *
    * @param pollingTask the polling task.
-   * @param period the polling period.
-   * @param unit the polling time unit.
+   * @param frequency the frequency to run the polling task at.
    * @param executorService the executor service to schedule the polling task on.
    * @return a future completing to the result of the polling task once that becomes available.
    */
   public static <T> CompletableFuture<T> poll(
       final Supplier<Optional<T>> pollingTask,
-      final long period, final TimeUnit unit,
+      final Duration frequency,
       final ScheduledExecutorService executorService) {
     final CompletableFuture<T> result = new CompletableFuture<>();
     final ScheduledFuture<?> scheduled = executorService.scheduleAtFixedRate(
-        () -> pollTask(pollingTask, result), 0, period, unit);
+        () -> pollTask(pollingTask, result), 0, frequency.toMillis(), TimeUnit.MILLISECONDS);
     result.whenComplete((r, ex) -> scheduled.cancel(true));
     return result;
   }

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Supplier;
@@ -53,6 +54,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
@@ -554,6 +556,18 @@ public class CompletableFuturesTest {
     future.cancel(true);
 
     verify(scheduledFuture).cancel(true);
+  }
+
+  @Test
+  public void poll_notRunningAfterCancel() throws Exception {
+    final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+    final CompletableFuture<String> future = poll(Optional::empty, Duration.ofMillis(2), executor);
+
+    future.cancel(true);
+    Thread.sleep(10);
+
+    final List<Runnable> running = executor.shutdownNow();
+    assertThat(running, is(empty()));
   }
 
   private static <T> CompletableFuture<T> incompleteFuture() {

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -25,6 +25,7 @@ import org.junit.rules.ExpectedException;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -492,7 +493,7 @@ public class CompletableFuturesTest {
   @Test
   public void poll_done() throws Exception {
     final Supplier<Optional<String>> supplier = () -> Optional.of("done");
-    final CompletableFuture<String> future = poll(supplier, 2, MILLISECONDS, executor);
+    final CompletableFuture<String> future = poll(supplier, Duration.ofMillis(2), executor);
 
     executor.runNextPendingCommand();
     assertThat(future, completesTo("done"));
@@ -508,7 +509,7 @@ public class CompletableFuturesTest {
   @Test
   public void poll_twice() throws Exception {
     final ExternalTask task = new ExternalTask();
-    final CompletableFuture<String> future = poll(task::done, 2, MILLISECONDS, executor);
+    final CompletableFuture<String> future = poll(task::done, Duration.ofMillis(2), executor);
 
     executor.tick(1, MILLISECONDS);
     assertThat(future.isDone(), is(false));
@@ -520,7 +521,7 @@ public class CompletableFuturesTest {
   @Test
   public void poll_taskReturnsNull() throws Exception {
     final Supplier<Optional<String>> supplier = () -> null;
-    final CompletableFuture<String> future = poll(supplier, 2, MILLISECONDS, executor);
+    final CompletableFuture<String> future = poll(supplier, Duration.ofMillis(2), executor);
 
     executor.runNextPendingCommand();
     exception.expectCause(isA(NullPointerException.class));
@@ -531,7 +532,7 @@ public class CompletableFuturesTest {
   public void poll_taskThrows() throws Exception {
     final RuntimeException ex = new RuntimeException("boom");
     final Supplier<Optional<String>> supplier = () ->  {throw ex;};
-    final CompletableFuture<String> future = poll(supplier, 2, MILLISECONDS, executor);
+    final CompletableFuture<String> future = poll(supplier, Duration.ofMillis(2), executor);
 
     executor.runNextPendingCommand();
     exception.expectCause(is(ex));
@@ -542,7 +543,7 @@ public class CompletableFuturesTest {
   public void poll_scheduled() throws Exception {
     final ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
     final Supplier<Optional<String>> supplier = () -> Optional.of("hello");
-    poll(supplier, 2, MILLISECONDS, executor);
+    poll(supplier, Duration.ofMillis(2), executor);
 
     verify(executor).scheduleAtFixedRate(any(), eq(0L), eq(2L), eq(MILLISECONDS));
   }
@@ -555,7 +556,7 @@ public class CompletableFuturesTest {
     when(executor.scheduleAtFixedRate(any(), anyLong(), anyLong(), any()))
         .thenReturn(scheduledFuture);
 
-    final CompletableFuture<String> future = poll(Optional::empty, 2, MILLISECONDS, executor);
+    final CompletableFuture<String> future = poll(Optional::empty, Duration.ofMillis(2), executor);
     future.cancel(true);
 
     verify(scheduledFuture).cancel(true);

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -501,10 +501,9 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void poll_twice() throws Exception {
-    final Supplier<Optional<String>> supplier = mock(Supplier.class);
-    when(supplier.get()).thenReturn(Optional.empty(), Optional.of("done"));
+    final List<Optional<String>> results = asList(Optional.empty(), Optional.of("done"));
+    final Supplier<Optional<String>> supplier = results.iterator()::next;
     final CompletableFuture<String> future = poll(supplier, Duration.ofMillis(2), executor);
 
     executor.tick(1, MILLISECONDS);


### PR DESCRIPTION
This periodically polls an external task until it returns a
non-empty result. My specific use-case here is talking to the
BigQuery API, where I have to send repeated HTTP requests until
the result becomes available.