### PR TITLE
Fix a bunch of Javadoc problems

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -35,7 +35,9 @@
         <module name="AvoidStarImport"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
-        <module name="UnusedImports"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,14 @@
   </developers>
 
   <dependencies>
+    <!-- provided dependencies -->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/spotify/futures/Function3.java
+++ b/src/main/java/com/spotify/futures/Function3.java
@@ -19,47 +19,49 @@ import java.util.Objects;
 import java.util.function.Function;
 
 /**
- * Represents a function that accepts three arguments and produces a result.
- * This is the three-arity specialization of {@link Function}.
+ * Represents a function that accepts three arguments and produces a result.  This is the
+ * three-arity specialization of {@link Function}.
  *
- * <p>This is a <a href="package-summary.html">functional interface</a>
- * whose functional method is {@link #apply(Object, Object, Object)}.
+ * <p> This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object)}.
  *
  * @param <A> the type of the first argument to the function
  * @param <B> the type of the second argument to the function
  * @param <C> the type of the third argument to the function
  * @param <R> the type of the result of the function
- *
  * @see Function
+ * @since 0.1.0
  */
 @FunctionalInterface
 public interface Function3<A, B, C, R> {
 
-    /**
-     * Applies this function to the given arguments.
-     *
-     * @param a the first function argument
-     * @param b the second function argument
-     * @param c the third function argument
-     * @return the function result
-     */
-    R apply(A a, B b, C c);
+  /**
+   * Applies this function to the given arguments.
+   *
+   * @param a the first function argument
+   * @param b the second function argument
+   * @param c the third function argument
+   * @return the function result
+   * @since 0.1.0
+   */
+  R apply(A a, B b, C c);
 
-    /**
-     * Returns a composed function that first applies this function to
-     * its input, and then applies the {@code after} function to the result.
-     * If evaluation of either function throws an exception, it is relayed to
-     * the caller of the composed function.
-     *
-     * @param <V> the type of output of the {@code after} function, and of the
-     *           composed function
-     * @param after the function to apply after this function is applied
-     * @return a composed function that first applies this function and then
-     * applies the {@code after} function
-     * @throws NullPointerException if after is null
-     */
-    default <V> Function3<A, B, C, V> andThen(Function<? super R, ? extends V> after) {
-        Objects.requireNonNull(after);
-        return (A a, B b, C c) -> after.apply(apply(a, b, c));
-    }
+  /**
+   * Returns a composed function that first applies this function to
+   * its input, and then applies the {@code after} function to the result.
+   * If evaluation of either function throws an exception, it is relayed to
+   * the caller of the composed function.
+   *
+   * @param <V>   the type of output of the {@code after} function, and of the
+   *              composed function
+   * @param after the function to apply after this function is applied
+   * @return a composed function that first applies this function and then
+   * applies the {@code after} function
+   * @throws NullPointerException if after is null
+   * @since 0.1.0
+   */
+  default <V> Function3<A, B, C, V> andThen(Function<? super R, ? extends V> after) {
+    Objects.requireNonNull(after);
+    return (A a, B b, C c) -> after.apply(apply(a, b, c));
+  }
 }

--- a/src/main/java/com/spotify/futures/Function4.java
+++ b/src/main/java/com/spotify/futures/Function4.java
@@ -19,49 +19,51 @@ import java.util.Objects;
 import java.util.function.Function;
 
 /**
- * Represents a function that accepts three arguments and produces a result.
- * This is the three-arity specialization of {@link Function}.
+ * Represents a function that accepts four arguments and produces a result.  This is the four-arity
+ * specialization of {@link Function}.
  *
- * <p>This is a <a href="package-summary.html">functional interface</a>
- * whose functional method is {@link #apply(Object, Object, Object, Object)}.
+ * <p> This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object, Object)}.
  *
  * @param <A> the type of the first argument to the function
  * @param <B> the type of the second argument to the function
  * @param <C> the type of the third argument to the function
  * @param <D> the type of the fourth argument to the function
  * @param <R> the type of the result of the function
- *
  * @see Function
+ * @since 0.1.0
  */
 @FunctionalInterface
 public interface Function4<A, B, C, D, R> {
 
-    /**
-     * Applies this function to the given arguments.
-     *
-     * @param a the first function argument
-     * @param b the second function argument
-     * @param c the third function argument
-     * @param d the fourth function argument
-     * @return the function result
-     */
-    R apply(A a, B b, C c, D d);
+  /**
+   * Applies this function to the given arguments.
+   *
+   * @param a the first function argument
+   * @param b the second function argument
+   * @param c the third function argument
+   * @param d the fourth function argument
+   * @return the function result
+   * @since 0.1.0
+   */
+  R apply(A a, B b, C c, D d);
 
-    /**
-     * Returns a composed function that first applies this function to
-     * its input, and then applies the {@code after} function to the result.
-     * If evaluation of either function throws an exception, it is relayed to
-     * the caller of the composed function.
-     *
-     * @param <V> the type of output of the {@code after} function, and of the
-     *           composed function
-     * @param after the function to apply after this function is applied
-     * @return a composed function that first applies this function and then
-     * applies the {@code after} function
-     * @throws NullPointerException if after is null
-     */
-    default <V> Function4<A, B, C, D, V> andThen(Function<? super R, ? extends V> after) {
-        Objects.requireNonNull(after);
-        return (A a, B b, C c, D d) -> after.apply(apply(a, b, c, d));
-    }
+  /**
+   * Returns a composed function that first applies this function to
+   * its input, and then applies the {@code after} function to the result.
+   * If evaluation of either function throws an exception, it is relayed to
+   * the caller of the composed function.
+   *
+   * @param <V>   the type of output of the {@code after} function, and of the
+   *              composed function
+   * @param after the function to apply after this function is applied
+   * @return a composed function that first applies this function and then
+   * applies the {@code after} function
+   * @throws NullPointerException if after is null
+   * @since 0.1.0
+   */
+  default <V> Function4<A, B, C, D, V> andThen(Function<? super R, ? extends V> after) {
+    Objects.requireNonNull(after);
+    return (A a, B b, C c, D d) -> after.apply(apply(a, b, c, d));
+  }
 }

--- a/src/main/java/com/spotify/futures/Function5.java
+++ b/src/main/java/com/spotify/futures/Function5.java
@@ -19,11 +19,11 @@ import java.util.Objects;
 import java.util.function.Function;
 
 /**
- * Represents a function that accepts three arguments and produces a result.
- * This is the three-arity specialization of {@link Function}.
+ * Represents a function that accepts five arguments and produces a result.  This is the five-arity
+ * specialization of {@link Function}.
  *
- * <p>This is a <a href="package-summary.html">functional interface</a>
- * whose functional method is {@link #apply(Object, Object, Object, Object, Object)}.
+ * <p> This is a functional interface whose functional method is
+ * {@link #apply(Object, Object, Object, Object, Object)}.
  *
  * @param <A> the type of the first argument to the function
  * @param <B> the type of the second argument to the function
@@ -31,39 +31,41 @@ import java.util.function.Function;
  * @param <D> the type of the fourth argument to the function
  * @param <E> the type of the fifth argument to the function
  * @param <R> the type of the result of the function
- *
  * @see Function
+ * @since 0.1.0
  */
 @FunctionalInterface
 public interface Function5<A, B, C, D, E, R> {
 
-    /**
-     * Applies this function to the given arguments.
-     *
-     * @param a the first function argument
-     * @param b the second function argument
-     * @param c the third function argument
-     * @param d the fourth function argument
-     * @param e the firth function argument
-     * @return the function result
-     */
-    R apply(A a, B b, C c, D d, E e);
+  /**
+   * Applies this function to the given arguments.
+   *
+   * @param a the first function argument
+   * @param b the second function argument
+   * @param c the third function argument
+   * @param d the fourth function argument
+   * @param e the firth function argument
+   * @return the function result
+   * @since 0.1.0
+   */
+  R apply(A a, B b, C c, D d, E e);
 
-    /**
-     * Returns a composed function that first applies this function to
-     * its input, and then applies the {@code after} function to the result.
-     * If evaluation of either function throws an exception, it is relayed to
-     * the caller of the composed function.
-     *
-     * @param <V> the type of output of the {@code after} function, and of the
-     *           composed function
-     * @param after the function to apply after this function is applied
-     * @return a composed function that first applies this function and then
-     * applies the {@code after} function
-     * @throws NullPointerException if after is null
-     */
-    default <V> Function5<A, B, C, D, E, V> andThen(Function<? super R, ? extends V> after) {
-        Objects.requireNonNull(after);
-        return (A a, B b, C c, D d, E e) -> after.apply(apply(a, b, c, d, e));
-    }
+  /**
+   * Returns a composed function that first applies this function to
+   * its input, and then applies the {@code after} function to the result.
+   * If evaluation of either function throws an exception, it is relayed to
+   * the caller of the composed function.
+   *
+   * @param <V>   the type of output of the {@code after} function, and of the
+   *              composed function
+   * @param after the function to apply after this function is applied
+   * @return a composed function that first applies this function and then
+   * applies the {@code after} function
+   * @throws NullPointerException if after is null
+   * @since 0.1.0
+   */
+  default <V> Function5<A, B, C, D, E, V> andThen(Function<? super R, ? extends V> after) {
+    Objects.requireNonNull(after);
+    return (A a, B b, C c, D d, E e) -> after.apply(apply(a, b, c, d, e));
+  }
 }

--- a/src/main/java/com/spotify/futures/package-info.java
+++ b/src/main/java/com/spotify/futures/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Extends the {@link java.util.concurrent.CompletableFuture Java completable future} API.  The main
+ * entry point of this package is the {@link com.spotify.futures.CompletableFutures} class, that
+ * contains useful static utility methods.
+ *
+ * <p> This package uses the convention that all method parameters are non-null by default, i.e.
+ * unless indicated by a {@link javax.annotation.Nullable @Nullable} annotation.
+ *
+ * @since 0.1.0
+ */
+@ParametersAreNonnullByDefault
+package com.spotify.futures;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This does the following:

- Corrects Javadoc that's just plain wrong (i.e. `Function5`: `accepts three arguments`)
- Fixes all warnings emitted by `mvn javadoc:javadoc` (including missing parameter documentation)
- Adds `{@link}` and `{@code}` where it makes sense
- Adds package-level documentation
- Annotates methods with the version number that they were introduced