### PR TITLE
Performance improvement

### DIFF
--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -62,19 +62,21 @@ public final class CompletableFutures {
    * @since 0.1.0
    */
   public static <T> CompletableFuture<List<T>> allAsList(
-      List<? extends CompletionStage<? extends T>> stages) {
+          final List<? extends CompletionStage<? extends T>> stages) {
     // We use traditional for-loops instead of streams here for performance reasons,
     // see AllAsListBenchmark
+    final int size = stages.size();
 
     @SuppressWarnings("unchecked") // generic array creation
-    final CompletableFuture<? extends T>[] all = new CompletableFuture[stages.size()];
-    for (int i = 0; i < stages.size(); i++) {
+    final CompletableFuture<? extends T>[] all = new CompletableFuture[size];
+    for (int i = 0; i < size; i++) {
       all[i] = stages.get(i).toCompletableFuture();
     }
     return CompletableFuture.allOf(all)
         .thenApply(ignored -> {
-          final List<T> result = new ArrayList<>(all.length);
-          for (int i = 0; i < all.length; i++) {
+          final int length = all.length;
+          final List<T> result = new ArrayList<>(length);
+          for (int i = 0; i < length; i++) {
             result.add(all[i].join());
           }
           return result;


### PR DESCRIPTION
## JMH for the old code => 802.984 ns/op

```
Result "actual":
  21734.998 ±(99.9%) 802.984 ns/op [Average]
  (min, avg, max) = (19540.622, 21734.998, 25702.090), stdev = 1622.067
  CI (99.9%): [20932.014, 22537.981] (assumes normal distribution)


# Run complete. Total time: 00:06:25

Benchmark                  (inputSize)  Mode  Cnt      Score     Error  Units
AllAsListBenchmark.actual            4  avgt   50     93.465 ±   1.880  ns/op
AllAsListBenchmark.actual           16  avgt   50    320.043 ±   6.123  ns/op
AllAsListBenchmark.actual           64  avgt   50   1213.432 ±  31.704  ns/op
AllAsListBenchmark.actual          256  avgt   50   5118.282 ± 177.067  ns/op
AllAsListBenchmark.actual         1024  avgt   50  21734.998 ± 802.984  ns/op
```

## JMH for the new code => 381.775 ns/op

```
Result "actual":
  19520.580 ±(99.9%) 381.775 ns/op [Average]
  (min, avg, max) = (18472.210, 19520.580, 21327.029), stdev = 771.205
  CI (99.9%): [19138.804, 19902.355] (assumes normal distribution)


# Run complete. Total time: 00:06:25

Benchmark                  (inputSize)  Mode  Cnt      Score     Error  Units
AllAsListBenchmark.actual            4  avgt   50     95.670 ±   2.884  ns/op
AllAsListBenchmark.actual           16  avgt   50    327.474 ±   7.080  ns/op
AllAsListBenchmark.actual           64  avgt   50   1262.304 ±  22.849  ns/op
AllAsListBenchmark.actual          256  avgt   50   5040.248 ±  97.250  ns/op
AllAsListBenchmark.actual         1024  avgt   50  19520.580 ± 381.775  ns/op
```