### PR TITLE
Add completedFutureFrom method

### DIFF
--- a/src/main/java/com/spotify/futures/CheckedSupplier.java
+++ b/src/main/java/com/spotify/futures/CheckedSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.futures;
+
+/**
+ * A checked version of {@link java.util.function.Supplier} to allow for getting
+ * elements but that might thrown an exception.
+ * @param <T> The type of result the supplier produces
+ * @see java.util.function.Supplier
+ * @since 0.4.0
+ */
+@FunctionalInterface
+public interface CheckedSupplier<T> {
+
+  /**
+   * Gets a result
+   * @return The result
+   * @throws Exception The supplier is allowed to throw an exception
+   */
+  T get() throws Exception;
+}

--- a/src/main/java/com/spotify/futures/CheckedSupplier.java
+++ b/src/main/java/com/spotify/futures/CheckedSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Spotify AB
+ * Copyright (c) 2017 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -125,6 +125,38 @@ public final class CompletableFutures {
   }
 
   /**
+   * Creates a {@link CompletionStage} from a supplier.
+   * {@link CheckedSupplier#get()} will be called immediately, and the stage
+   * will immediately be successful with the value of the supplier.
+   *
+   * <p> If the supplier throws an {@link Exception} then the future will
+   * complete exceptionally with that exception.
+   *
+   * <p> It could be useful to use this function to wrap functions that should return
+   * a stage but might throw an exception. For example
+   *
+   * <pre>{@code
+   * CompletionStage<Pojo> parseJson(final byte[] bytes) {
+   *   // parse might throw IOException!!
+   *   return completedFuture(() -> jsonParser.parse(bytes));
+   * }
+   * }</pre>
+   *
+   * @param supplier A {@link CheckedSupplier} to supply the value to the future
+   * @param <T> The return type of the supplier
+   * @return A completed
+   * @see CompletableFuture#supplyAsync(Supplier)
+   * @since 0.4.0
+   */
+  public static <T> CompletionStage<T> completedFutureFrom(CheckedSupplier<T> supplier) {
+    try {
+      return CompletableFuture.completedFuture(supplier.get());
+    } catch (Exception ex) {
+      return exceptionallyCompletedFuture(ex);
+    }
+  }
+
+  /**
    * Collect a stream of {@link CompletionStage}s into a single future holding a list of the
    * joined entities.
    *

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -360,7 +360,7 @@ public class CompletableFuturesTest {
 
   @Test
   public void dereference_null() throws Exception {
-    final CompletionStage<Object> dereferenced = dereference(completedFutureFrom(null));
+    final CompletionStage<Object> dereferenced = dereference(completedFuture(null));
 
     exception.expectCause(isA(NullPointerException.class));
     getCompleted(dereferenced);


### PR DESCRIPTION
This method is to be used to create completed futures
but in a way that is safe from leaking exceptions.

Today, one can do something like this,

```java
CompletionStage<String> getValue() {
  return completedFuture(computeValue());
}
```

but if `computeValue()` would throw then this exception leaks
synchronously and will break.

To handle this, one can do

```java
CompletionStage<String> getValue() {
  try {
    return completedFuture(computeValue());
  } catch (Exception e) {
    return exceptionallyCompletedFuture(e);
  }
}
```

but it is hard and burdemsome to always remember to handle that
exception.

This patch proposes a new alternative, but using a checked supplier;

```java
CompletionStage<String> getValue() {
  // if an exception thrown then stage is exceptionally completed
  return completedFutureFrom(this::computeValue);
}
```