### PR TITLE
Switch to openjdk to fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk: 
   - openjdk8
-  - openjdk11
 
 sudo: false
 install: true # This runs the "true" command in the install phase; thus skipping install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
-jdk: oraclejdk8
+jdk: 
+  - openjdk8
+  - openjdk11
 
 sudo: false
 install: true # This runs the "true" command in the install phase; thus skipping install
@@ -15,12 +17,6 @@ before_script:
   - pip install --user codecov
 after_success:
   - codecov
-
-# Because of bug: https://github.com/travis-ci/travis-ci/issues/3259
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
 
 cache:
   directories:


### PR DESCRIPTION
Seems like Travis can't install the Oracle JDK anymore. I haven't looked into it much, but seems to be a common problem and the recommendation is to switch to openjdk.

For an example of a failing build, see https://travis-ci.com/spotify/completable-futures/builds/131820004