### PR TITLE
Fail fast implementation for joinList

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target/
 pom.xml.releaseBackup
 release.properties
+*.iml

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ collection.stream()
     .thenApply(this::consumeList)
 ```
 
+To fail fast as soon as one of the asynchronous operations completed exceptionally, a `FailFast` behavior can be specified as parameter:
+```java
+collection.stream()
+    .map(this::someAsyncFunction)
+    .collect(CompletableFutures.joinList(new FailFastWithThrowable(TimeoutException.class)))
+    .thenApply(this::consumeList)
+```
+
 #### combine
 
 If you want to combine more than two futures of different types, use the `combine` method:

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,16 @@
       </roles>
       <timezone>+1</timezone>
     </developer>
+    <developer>
+      <id>JoseAlavez</id>
+      <name>Jose Alavez</name>
+      <email>414v32@gmail.com</email>
+      <url>https://github.com/JoseAlavez</url>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>+2</timezone>
+    </developer>
   </developers>
 
   <dependencies>

--- a/src/main/java/com/spotify/futures/ExecutionMetadata.java
+++ b/src/main/java/com/spotify/futures/ExecutionMetadata.java
@@ -1,0 +1,67 @@
+package com.spotify.futures;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Provides execution metadata in relation to a group of completable futures.
+ *
+ * @author Jose Alavez
+ * @since 0.3.3
+ */
+public class ExecutionMetadata {
+
+  private final CompletableFuture<?>[] all;
+
+  ExecutionMetadata(CompletableFuture<?>... all) {
+    this.all = all;
+  }
+
+  private int accumulate(Function<CompletableFuture<?>, Boolean> fn) {
+    int accumulator = 0;
+    for (int i = 0; i < all.length; i++) {
+      if (fn.apply(all[i])) {
+        accumulator++;
+      }
+    }
+    return accumulator;
+  }
+
+  /**
+   * Returns the total of completable futures being combined.
+   */
+  public int getTotal() {
+    return all.length;
+  }
+
+  /**
+   * Returns the total of completable futures that have been completed normally, exceptionally or
+   * via cancellation.
+   *
+   * @see CompletableFuture#isDone()
+   */
+  public int getDone() {
+    return accumulate(CompletableFuture::isDone);
+  }
+
+  /**
+   * Returns the total of completable futures that have been completed normally.
+   *
+   * @see CompletableFuture#isDone()
+   * @see CompletableFuture#isCompletedExceptionally()
+   */
+  public int getCompletedNormally() {
+    return accumulate(
+        completableFuture ->
+            completableFuture.isDone() && !completableFuture.isCompletedExceptionally());
+  }
+
+  /**
+   * Returns the total of completable futures that have been completed exceptionally, in any way.
+   *
+   * @see CompletableFuture#isCompletedExceptionally()
+   */
+  public int getCompletedExceptionally() {
+    return accumulate(CompletableFuture::isCompletedExceptionally);
+  }
+}

--- a/src/main/java/com/spotify/futures/FailFast.java
+++ b/src/main/java/com/spotify/futures/FailFast.java
@@ -1,0 +1,40 @@
+package com.spotify.futures;
+
+/**
+ * Interface that defines fail fast behavior when combining several completion stages in a
+ * completable future.
+ *
+ * @author Jose Alavez
+ * @since 0.3.3
+ */
+public interface FailFast {
+
+  /**
+   * Evaluates if the {@code throwable} should lead to a fast failure when combining completion
+   * stages together. A fast failure will not wait for all the combined stages to complete normally
+   * or exceptionally.
+   *
+   * @param throwable         A {@link Throwable} returned by a exceptionally completed stage.
+   * @param executionMetadata A {@link ExecutionMetadata} that provides data related to current
+   *                          execution.
+   * @return {@code true} if the combined completable future should fail fast, {@code false} if
+   * otherwise.
+   */
+  boolean failFast(Throwable throwable, ExecutionMetadata executionMetadata);
+
+  /**
+   * Specifies a {@link Throwable} instance to return when a combined completable future fail fast.
+   *
+   * @param origin A {@link Throwable} that originated the fail fast.
+   * @return A {@link Throwable} to used to complete exceptionally a combined completable future.
+   */
+  Throwable withThrowable(Throwable origin);
+
+  /**
+   * Defines if all the incomplete stages should be cancelled when failing fast.
+   *
+   * @return {@code true} if all the incomplete stages should be cancelled when failing fast, {@code
+   * false} if otherwise.
+   */
+  boolean cancelAll();
+}

--- a/src/main/java/com/spotify/futures/FailFastWithThrowable.java
+++ b/src/main/java/com/spotify/futures/FailFastWithThrowable.java
@@ -1,0 +1,59 @@
+package com.spotify.futures;
+
+import static java.util.Arrays.asList;
+
+import java.util.Collection;
+
+/**
+ * Fail fast implementation that completes exceptionally when one of the stages completes
+ * exceptionally matching a specific throwable class.
+ *
+ * <p>This implementation maintains the originating {@link Throwable} causing the fast failure and
+ * propagates it through the combined completable future.
+ *
+ * <p>This implementation cancels all the remaining incomplete completable futures when failing
+ * fast.
+ *
+ * @author Jose Alavez
+ * @see FailFast
+ * @since 0.3.3
+ */
+public class FailFastWithThrowable implements FailFast {
+
+  private final Collection<Class<? extends Throwable>> classes;
+
+  /**
+   * @see FailFastWithThrowable#FailFastWithThrowable(java.util.Collection)
+   */
+  @SafeVarargs
+  public FailFastWithThrowable(Class<? extends Throwable>... throwableClasses) {
+    this(asList(throwableClasses));
+  }
+
+  /**
+   * @param throwableClasses {@link Collection} of throwable classes to fail fast.
+   */
+  public FailFastWithThrowable(Collection<Class<? extends Throwable>> throwableClasses) {
+    this.classes = throwableClasses;
+  }
+
+  @Override
+  public boolean cancelAll() {
+    return true;
+  }
+
+  @Override
+  public Throwable withThrowable(Throwable origin) {
+    return origin;
+  }
+
+  @Override
+  public boolean failFast(Throwable throwable, ExecutionMetadata executionMetadata) {
+
+    if (throwable.getCause() != null) {
+      return classes.contains(throwable.getCause().getClass());
+    }
+
+    return classes.contains(throwable.getClass());
+  }
+}

--- a/src/test/java/com/spotify/futures/ExecutionMetadataTest.java
+++ b/src/test/java/com/spotify/futures/ExecutionMetadataTest.java
@@ -1,0 +1,54 @@
+package com.spotify.futures;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExecutionMetadataTest {
+
+  ExecutionMetadata executionMetadata;
+
+  @Before
+  public void setup() {
+    CompletableFuture<?> normallyCompletedFuture = completedFuture(1);
+
+    CompletableFuture<?> exceptionallyCompletedFuture = new CompletableFuture<>();
+    exceptionallyCompletedFuture.completeExceptionally(new NullPointerException());
+
+    CompletableFuture<?> cancelledFuture = new CompletableFuture<>();
+    cancelledFuture.cancel(true);
+
+    CompletableFuture<?> incompleteFuture = new CompletableFuture<>();
+
+    executionMetadata =
+        new ExecutionMetadata(
+            normallyCompletedFuture,
+            exceptionallyCompletedFuture,
+            cancelledFuture,
+            incompleteFuture);
+  }
+
+  @Test
+  public void testGetCompletedNormally() {
+    assertThat(executionMetadata.getCompletedNormally(), is(1));
+  }
+
+  @Test
+  public void testGetCompletedExceptionally() {
+    assertThat(executionMetadata.getCompletedExceptionally(), is(2));
+  }
+
+  @Test
+  public void testGetDone() {
+    assertThat(executionMetadata.getDone(), is(3));
+  }
+
+  @Test
+  public void testGetTotal() {
+    assertThat(executionMetadata.getTotal(), is(4));
+  }
+}

--- a/src/test/java/com/spotify/futures/FailFastWithThrowableTest.java
+++ b/src/test/java/com/spotify/futures/FailFastWithThrowableTest.java
@@ -1,0 +1,58 @@
+package com.spotify.futures;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FailFastWithThrowableTest {
+
+  FailFastWithThrowable failFastWithThrowable;
+
+  @Before
+  public void setup() {
+    failFastWithThrowable = new FailFastWithThrowable(singletonList(TimeoutException.class));
+  }
+
+  @Test
+  public void testCancelAll() {
+    assertThat(failFastWithThrowable.cancelAll(), is(true));
+  }
+
+  @Test
+  public void testWithThrowable() {
+    TimeoutException expectedThrowable = new TimeoutException();
+    assertThat(failFastWithThrowable.withThrowable(expectedThrowable), is(expectedThrowable));
+  }
+
+  @Test
+  public void testFailFastWithDifferentException() {
+    assertThat(
+        failFastWithThrowable.failFast(new NullPointerException(), new ExecutionMetadata()),
+        is(false));
+  }
+
+  @Test
+  public void testFailFastWithMatchingException() {
+    assertThat(
+        failFastWithThrowable.failFast(new TimeoutException(), new ExecutionMetadata()), is(true));
+  }
+
+  @Test
+  public void testFailFastWithDifferentCause() {
+    CompletionException completionException = new CompletionException(new NullPointerException());
+    assertThat(
+        failFastWithThrowable.failFast(completionException, new ExecutionMetadata()), is(false));
+  }
+
+  @Test
+  public void testFailFastWithMatchingCause() {
+    CompletionException completionException = new CompletionException(new TimeoutException());
+    assertThat(
+        failFastWithThrowable.failFast(completionException, new ExecutionMetadata()), is(true));
+  }
+}


### PR DESCRIPTION
Hi, we use this library on one of the projects I work on and I noticed an undesirable behavior that gets improved with this PR. 

# Context:
We use this library in combination with Netty, to consume REST APIs that provide us with single fetch contracts (as for example `GET /domain/resource/{id}`). In other words, when we require to fetch a batch of resources by id, we create individual asynchronous HTTP calls to the respective APIs and then join the completable futures using `.collect(CompletableFutures.joinList())`.

When our app is under heavy load and our fetch batch logic leads to individual HTTP calls that grows dramatically, we are seeing execution times that are higher than the timeouts specified for each completable future. This is caused due to the capacity of our executor to perform each HTTP call (and queuing) but also because the current implementation of `joinList` and `allAsList` utilizes `CompletableFuture#allOf`, which will wait until all the states are completed to either continue normally or exceptionally.

# Proposal
I took the chance of implementing a extendable `fail fast` behavior in the `joinList` and `allAsList` methods. An interface that can have multiple implementations can be passed as parameter to define how and when the combined completable future needs to fail fast (complete exceptionally) once one or more stages fail. Furthermore, the execution of the incomplete stages can be cancelled when failing fast ([understanding that it will cancel further stage chaining and not the current execution of the stage](https://dzone.com/articles/completablefuture-cant-be)).

# Side Notes:
* I tried to honor as much the current coding style and practices (as for example, favoring conventional for statements or snake case on test method names for `CompletableFuturesTest.java`). Please advise if this is yet necessary or if the code can be simplified. 
* Checking stackoverflow.com seems there is a need in the community for this behavior to be implemented ([ref1](https://stackoverflow.com/questions/51621510/how-to-implement-completablefuture-allof-that-completes-exceptionally-once-any), [ref2](https://stackoverflow.com/questions/58491368/completablefuture-allof-cancel-other-futures-when-one-throws-exception)). I thought this library is a nice candidate to contain a solution for it.


Let me know if this PR brings value to the code base (as we look forward to use it in our project), or if anything here needs to be adapted or if the request would be discarded. 




