### PR TITLE
Fail fast implementation for joinList

### DIFF
--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -37,6 +37,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
 
 import static com.spotify.futures.CompletableFutures.allAsList;
 import static com.spotify.futures.CompletableFutures.allAsMap;
@@ -64,6 +66,7 @@ import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.Is.isA;
@@ -71,6 +74,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
@@ -123,6 +127,23 @@ public class CompletableFuturesTest {
 
     exception.expectCause(is(ex));
     allAsList(input).get();
+  }
+
+  @Test
+  public void allAsList_exceptional_failFast() {
+    final CompletableFuture<String> incomplete = incompleteFuture();
+    final CompletableFuture<String> failed =
+        exceptionallyCompletedFuture(new TimeoutException());
+    final List<CompletionStage<String>> input =
+        asList(incomplete, failed);
+
+    try {
+      allAsList(input).join();
+      fail("Expected exception being thrown.");
+    } catch (Exception e) {
+      assertThat(e, instanceOf(CompletionException.class));
+      assertThat(e.getCause(), instanceOf(TimeoutException.class));
+    }
   }
 
   @Test


### PR DESCRIPTION
Hi, we use this library on one of the projects I work on and I noticed an undesirable behavior that gets improved with this PR. 

# Context:
We use this library in combination with Netty, to consume REST APIs that provide us with single fetch contracts (as for example `GET /domain/resource/{id}`). In other words, when we require to fetch a batch of resources by id, we create individual asynchronous HTTP calls to the respective APIs and then join the completable futures using `.collect(CompletableFutures.joinList())`.

When our app is under heavy load and our fetch batch logic leads to individual HTTP calls that grows dramatically, we are seeing execution times that are higher than the timeouts specified for each completable future. This is caused due to the capacity of our executor to perform each HTTP call (and queuing) but also because the current implementation of `joinList` and `allAsList` utilizes `CompletableFuture#allOf`, which will wait until all the states are completed to either continue normally or exceptionally.

# Proposal
I took the chance of implementing a extendable `fail fast` behavior in the `joinList` and `allAsList` methods. An interface that can have multiple implementations can be passed as parameter to define how and when the combined completable future needs to fail fast (complete exceptionally) once one or more stages fail. Furthermore, the execution of the incomplete stages can be cancelled when failing fast ([understanding that it will cancel further stage chaining and not the current execution of the stage](https://dzone.com/articles/completablefuture-cant-be)).

# Side Notes:
* I tried to honor as much the current coding style and practices (as for example, favoring conventional for statements or snake case on test method names for `CompletableFuturesTest.java`). Please advise if this is yet necessary or if the code can be simplified. 
* Checking stackoverflow.com seems there is a need in the community for this behavior to be implemented ([ref1](https://stackoverflow.com/questions/51621510/how-to-implement-completablefuture-allof-that-completes-exceptionally-once-any), [ref2](https://stackoverflow.com/questions/58491368/completablefuture-allof-cancel-other-futures-when-one-throws-exception)). I thought this library is a nice candidate to contain a solution for it.


Let me know if this PR brings value to the code base (as we look forward to use it in our project), or if anything here needs to be adapted or if the request would be discarded. 




