### PR TITLE
Added CompletableFutures.joinMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ collection.stream()
     .thenApply(this::consumeList)
 ```
 
+#### joinMap
+
+`joinMap` is a stream collector that applies an asynchronous operation to each element of the stream, and associates the result of that 
+operation to a key derived from the original element. This is useful when you need to keep the association between the entity that triggered
+the asynchronous operation and the result of that operation:
+
+```java
+collection.stream()
+    .collect(joinMap(this::toKey, this::someAsyncFunc))
+    .thenApply(this::consumeMap)
+```
+
 #### combine
 
 If you want to combine more than two futures of different types, use the `combine` method:

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ collection.stream()
 
 #### joinMap
 
-`joinMap` is a stream collector that applies an asynchronous operation to each element of the stream, and associates the result of that 
-operation to a key derived from the original element. This is useful when you need to keep the association between the entity that triggered
-the asynchronous operation and the result of that operation:
+`joinMap` is a stream collector that applies an asynchronous operation to each element of the 
+stream, and associates the result of that operation to a key derived from the original element. 
+This is useful when you need to keep the association between the entity that triggered the 
+asynchronous operation and the result of that operation:
 
 ```java
 collection.stream()

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -21,6 +21,7 @@ package com.spotify.futures;
 
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -210,6 +211,43 @@ public final class CompletableFutures {
   public static <T, S extends CompletionStage<? extends T>>
   Collector<S, ?, CompletableFuture<List<T>>> joinList() {
     return collectingAndThen(toList(), CompletableFutures::allAsList);
+  }
+
+  /**
+   * Collect a stream of Objects into a single future holding a Map whose keys are the result of
+   * applying the provided mapping function to the input elements, and whose values are the
+   * corresponding joined entities.
+   *
+   * <p> Usage:
+   *
+   * <pre>{@code
+   * collection.stream()
+   *     .collect(joinMap(this::toKey, this::someAsyncFunc))
+   *     .thenApply(this::consumeMap)
+   * }</pre>
+   *
+   * <p> The generated {@link CompletableFuture} will complete to a Map of all entities. Similar
+   * to {@link CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures
+   * complete exceptionally, then the returned CompletableFuture also does so, with a
+   * {@link CompletionException} holding this exception as its cause.
+   *
+   * @param keyMapper a mapping function to produce keys
+   * @param valueFutureMapper a mapping function to produce futures that will eventually produce
+   *                          the values
+   * @param <T> the type of the input elements
+   * @param <K> the output type of the key mapping function
+   * @param <V> the common super-type of the stages returned by the value future mapping function
+   * @return a new {@link CompletableFuture} according to the rules outlined in the method
+   * description
+   * @throws NullPointerException if valueFutureMapper returns {@code null} for any input element
+   * @since 0.3.4
+   */
+  public static <T, K, V> Collector<T, ?, CompletableFuture<Map<K, V>>> joinMap(
+          Function<? super T, ? extends K> keyMapper,
+          Function<? super T, ? extends CompletionStage<? extends V>> valueFutureMapper){
+    Collector<T, ?, Map<K, CompletionStage<? extends V>>> collector =
+            toMap(keyMapper, valueFutureMapper);
+    return collectingAndThen(collector, CompletableFutures::allAsMap);
   }
 
   /**

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -70,6 +70,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -438,14 +439,12 @@ public class CompletableFuturesTest {
 
   @Test
   public void joinMap_two() throws Exception {
-    final CompletableFuture<String> a = completedFuture("hello");
-    final CompletableFuture<String> b = completedFuture("world");
-
     final Map<String, String> result = Stream.of("hello", "world")
             .collect(joinMap(e -> "k " + e, e -> completedFuture("v " + e)))
             .get();
-    assertThat(result.keySet(), contains("k hello", "k world"));
-    assertThat(result.values(), contains("v hello", "v world"));
+    assertThat(result.entrySet(), hasSize(2));
+    assertThat(result, hasEntry("k hello", "v hello"));
+    assertThat(result, hasEntry("k world", "v world"));
   }
 
   @Test

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -55,6 +55,7 @@ import static com.spotify.futures.CompletableFutures.getCompleted;
 import static com.spotify.futures.CompletableFutures.getException;
 import static com.spotify.futures.CompletableFutures.handleCompose;
 import static com.spotify.futures.CompletableFutures.joinList;
+import static com.spotify.futures.CompletableFutures.joinMap;
 import static com.spotify.futures.CompletableFutures.poll;
 import static com.spotify.futures.CompletableFutures.successfulAsList;
 import static java.util.Arrays.asList;
@@ -65,6 +66,7 @@ import static java.util.Collections.singletonMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
@@ -411,6 +413,62 @@ public class CompletableFuturesTest {
 
     exception.expect(NullPointerException.class);
     stream.collect(joinList());
+  }
+
+  @Test
+  public void joinMap_empty() throws Exception {
+    final Map<String, String> result = Stream.<String>of()
+            .collect(joinMap(identity(), CompletableFuture::completedFuture))
+            .get();
+
+    assertThat(result, not(nullValue()));
+    assertThat(result.values(), hasSize(0));
+  }
+
+  @Test
+  public void joinMap_one() throws Exception {
+    final Map<String, String> result = Stream.of("a")
+            .collect(joinMap(identity(), k -> completedFuture(k + "v")))
+            .get();
+
+    assertThat(result.values(), hasSize(1));
+    assertThat(result.values(), contains("av"));
+    assertThat(result.keySet(), contains("a"));
+  }
+
+  @Test
+  public void joinMap_two() throws Exception {
+    final CompletableFuture<String> a = completedFuture("hello");
+    final CompletableFuture<String> b = completedFuture("world");
+
+    final Map<String, String> result = Stream.of("hello", "world")
+            .collect(joinMap(e -> "k " + e, e -> completedFuture("v " + e)))
+            .get();
+    assertThat(result.keySet(), contains("k hello", "k world"));
+    assertThat(result.values(), contains("v hello", "v world"));
+  }
+
+  @Test
+  public void joinMap_exceptional() throws Exception {
+    final RuntimeException ex = new RuntimeException("boom");
+    final CompletableFuture<String> a = completedFuture("hello");
+    final CompletableFuture<String> b = exceptionallyCompletedFuture(ex);
+
+    final CompletableFuture<Map<String, String>> result = Stream.of("a", "b")
+            .collect(joinMap(identity(), v -> v.equals("a") ? a : b));
+
+    exception.expectCause(is(ex));
+    result.get();
+  }
+
+  @Test
+  public void joinMap_containsNull() throws Exception {
+    final CompletableFuture<String> a = completedFuture("hello");
+    final CompletableFuture<String> b = null;
+    final Stream<String> stream = Stream.of("a", "b");
+
+    exception.expect(NullPointerException.class);
+    stream.collect(joinMap(identity(), v -> v.equals("a") ? a : b));
   }
 
   @Test


### PR DESCRIPTION
Adds CompletableFutures.joinMap(). 

`joinMap()` is to `allAsMap()` as `joinList()` is to `allAsList()`: a stream collector that does the same operation without forcing the user to use a temporary variable. This is especially useful since `Map` declarations with both key and value type are considerably more visually cluttered than `List` declarations.