### PR TITLE
Added unravel() to make it easier to work with CompletionExceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ the various flavors of `unravelled()` can be used to make sure the exception rec
 lambda has already been unravelled:
 
 ```java
-future.exceptionally(ex -> {
+future.exceptionally(unravelled(ex -> {
     if(ex instanceof BusinessRelevantException){
         return emptyValue();
     }
     throw new CompletionException(ex);
-});
+}));
 ```
 
 ### Scheduling

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ catch(Throwable ex){
 }
 ```
 
+There is also `unravel(Callable<V>)` which can be used together with `join()` or  `get()` and 
+allows you to use the standard catch statement to differentiate between exception types:
+
+```java
+try {
+    String value = unravel(future::join);
+} 
+catch(BusinessRelevantException ex){
+    handleBusinessException(ex);
+}
+catch(Throwable ex){
+	logAndFail(ex);
+}
+```
+
 In order to simplify the lambdas passed in `exceptionally()`, `handle()` and `whenComplete()` 
 the various flavors of `unravelled()` can be used to make sure the exception received by the
 lambda has already been unravelled:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ When handling exceptions thrown by `join()` and `get()` or received in `whenComp
 obtained is going to be a `CompletionException` or some other `Throwable`. Even when we know
 that the exception is guaranteed to be a `CompletionException`, it can be hard to know ahead
 of time if `ex.getCause()` is going to be another `CompletionException`, an actually useful
-`Throwable`, or deeply nested the `CompletionExceptions` might be.
+`Throwable`, or how deeply nested the `CompletionExceptions` might be.
 
 `unravel(Throwable)` will recursively unwrap `CompletionExceptions` at the top of the exception
 chain. It can be used this way:
@@ -179,11 +179,11 @@ catch(Throwable ex){
 ```
 
 In order to simplify the lambdas passed in `exceptionally()`, `handle()` and `whenComplete()` 
-the various flavors of `unravelled()` can be used to make sure the exception received by the
-lambda has already been unravelled:
+some overloads of `unravel()` can be used to make sure the exception received by the lambda 
+has already been unravelled:
 
 ```java
-future.exceptionally(unravelled(ex -> {
+future.exceptionally(unravel(ex -> {
     if(ex instanceof BusinessRelevantException){
         return emptyValue();
     }

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -713,6 +714,14 @@ public final class CompletableFutures {
       return throwable;
     }
     return unravel(cause);
+  }
+
+  public static <T> T unravel(Callable<T> callable) throws Throwable {
+    try {
+      return callable.call();
+    } catch(CompletionException ex){
+      throw unravel(ex);
+    }
   }
 
   public static <T> Function<Throwable, T> unravelled(Function<Throwable, T> function) {

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -757,8 +757,8 @@ public final class CompletableFutures {
   /**
    * Calls the specified callable catching any thrown CompletionException, unravelling it
    * and throwing the unravelled exception instead.
-   * <p>
-   * This method is convenient to use to unravel exceptions thrown by {@code join()} or
+   *
+   * <p>This method is convenient to use to unravel exceptions thrown by {@code join()} or
    * {@code get()}
    * <pre>
    * try {
@@ -768,7 +768,7 @@ public final class CompletableFutures {
    *     handleBusinessException(ex);
    * }
    * catch(Throwable ex){
-   * 	logAndFail(ex);
+   *     logAndFail(ex);
    * }
    * </pre>
    *
@@ -779,7 +779,7 @@ public final class CompletableFutures {
   public static <T> T unravel(Callable<T> callable) throws Throwable {
     try {
       return callable.call();
-    } catch(CompletionException ex){
+    } catch(CompletionException ex) {
       throw unravel(ex);
     }
   }
@@ -787,8 +787,8 @@ public final class CompletableFutures {
   /**
    * Returns a new {@code Function} that calls the specified {@code Function} after
    * unravelling the throwable passed as parameter.
-   * <p>
-   * This method is convenient to use with {@code exceptionally()} to ensure that the
+   *
+   * <p>This method is convenient to use with {@code exceptionally()} to ensure that the
    * {@code Throwable} received as parameter is already unravelled.
    * <pre>
    * future.exceptionally(unravel(ex -> {
@@ -812,8 +812,8 @@ public final class CompletableFutures {
    * Returns a new {@code BiFunction} that calls the specified {@code BiFunction} after
    * unravelling the throwable passed as first parameter. The second parameter is passed as-is
    * to the specified {@code BiFunction}
-   * <p>
-   * This method is convenient to use with {@code handle()} to ensure that the
+   *
+   * <p>This method is convenient to use with {@code handle()} to ensure that the
    * {@code Throwable} received as parameter is already unravelled.
    * <pre>
    * future.handle((value, ex) -> {
@@ -840,8 +840,8 @@ public final class CompletableFutures {
    * Returns a new {@code BiConsumer} that calls the specified {@code BiConsumer} after
    * unravelling the throwable passed as first parameter. The second parameter is passed as-is
    * to the specified {@code BiConsumer}
-   * <p>
-   * This method is convenient to use with {@code whenComplete()} to ensure that the
+   *
+   * <p>This method is convenient to use with {@code whenComplete()} to ensure that the
    * {@code Throwable} received as parameter is already unravelled.
    * <pre>
    * future.whenComplete((value, ex) -> {


### PR DESCRIPTION
I often have to add this annoying boilerplate code to unwrap CompletionExceptions (potentially multiple layers of them, or sometimes none at all), so I thought this might be a useful addition to this library.

This is a draft PR with missing comments and tests, just to see if people are interested, and to see if it is worth the effort of writing the missing bits. 

See the changes to README.md for use cases.