### PR TITLE
fix compilation error on javac 11

### DIFF
--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -388,7 +388,9 @@ public class CompletableFuturesTest {
     final CompletionStage<Integer> a = completedFuture(3);
     final CompletableFuture<Long> b = completedFuture(4L);
 
-    final List<? extends Number> result = Stream.of(a, b)
+    final Stream<? extends CompletionStage<? extends Number>> s = Stream.of(a, b);
+
+    final List<? extends Number> result = s
         .collect(joinList())
         .get();
     assertThat(result, contains(3, 4L));


### PR DESCRIPTION
The code as-is fails to compile for me with a javac version 11:

```
$ mvn -V test
Apache Maven 3.8.1 (05c21c65bdfed0f71a2f2ada8b84da59348c4c5d)
Maven home: /usr/local/Cellar/maven/3.8.1/libexec
Java version: 11.0.6, vendor: AdoptOpenJDK, runtime: /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
...
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/mattbrown/code/completable-futures/src/test/java/com/spotify/futures/CompletableFuturesTest.java:[393,13] incompatible types: java.util.List<java.lang.Object> cannot be converted to java.util.List<? extends java.lang.Number>
[INFO] 1 error
```

but it compiles fine with 8.

This small refactoring seems to appease the type gods (on both versions).