### PR TITLE
Add successfulAsList methods with partial failure actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ returns a future which completes to a map of all key values of its inputs:
   CompletableFuture<Map<String, String>> joined = CompletableFutures.allAsMap(futures);
 ```
 
-#### successfulAsList
+#### successfulAsList with default values
 
 Works like `allAsList`, but futures that fail will not fail the joined future. Instead, the
 defaultValueMapper function will be called once for each failed future and value returned will be
@@ -62,6 +62,35 @@ List<CompletableFuture<String>> input = asList(
     completedFuture("a"),
     exceptionallyCompletedFuture(new RuntimeException("boom")));
 CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(input, t -> "default");
+```
+
+#### successfulAsList with partial failure action
+
+Works like `allAsList`, but futures that fail will not fail the joined future. Instead, the provided
+partial failure action will be called with the exceptions of the failed futures.
+
+```java
+List<CompletableFuture<String>> input = asList(
+    completedFuture("a"),
+    exceptionallyCompletedFuture(new RuntimeException("boom")));
+CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(
+    input,
+    exceptions -> { System.err.println("Futures failed: " + exceptions); });
+```
+
+#### successfulAsList with partial failure action and predicate
+
+Works like `successfulAsList` with partial failure action, but only returns values that satisfy a
+predicate.
+
+```java
+List<CompletableFuture<String>> input = asList(
+    completedFuture("a"),
+    exceptionallyCompletedFuture(new RuntimeException("boom")));
+CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(
+    input,
+    exceptions -> System.err.println("Futures failed: " + exceptions),
+    value -> value.equals("a"));
 ```
 
 #### joinList

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ returns a future which completes to a map of all key values of its inputs:
   CompletableFuture<Map<String, String>> joined = CompletableFutures.allAsMap(futures);
 ```
 
-#### successfulAsList with default values
+#### successfulAsList with default value mapper
 
 Works like `allAsList`, but futures that fail will not fail the joined future. Instead, the
 defaultValueMapper function will be called once for each failed future and value returned will be

--- a/src/main/java/com/spotify/futures/StageFailureException.java
+++ b/src/main/java/com/spotify/futures/StageFailureException.java
@@ -1,0 +1,36 @@
+/*-
+ * -\-\-
+ * completable-futures
+ * --
+ * Copyright (C) 2016 - 2021 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.futures;
+
+import java.util.List;
+
+/**
+ * Indicates that one or more {@link java.util.concurrent.CompletionStage}s failed. The exceptions
+ * of the failed stages are stored as suppressed exceptions.
+ */
+class StageFailureException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  StageFailureException(String message, List<Throwable> exceptions) {
+    super(message);
+    exceptions.forEach(this::addSuppressed);
+  }
+}

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -309,22 +309,38 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureAction_allStagesSucceed_successfulResultsReturned() {
+  public void successfulAsListWithPartialFailureAction_allStagesSucceed_resultsReturned() {
     final String result1 = "a";
     final String result2 = "b";
-    final List<CompletionStage<String>> input =
-        asList(completedFuture(result1), completedFuture(result2));
+    final List<CompletionStage<String>> input = asList(
+        completedFuture(result1),
+        completedFuture(result2)
+    );
 
     assertThat(successfulAsList(input, partialFailureAction),
         completesTo(asList(result1, result2)));
   }
 
   @Test
+  public void successfulAsListWithPartialFailureAction_allStagesSucceed_partialFailureActionNotCalled() {
+    final List<CompletionStage<String>> input = asList(
+        completedFuture("a"),
+        completedFuture("b")
+    );
+
+    successfulAsList(input, partialFailureAction).join();
+
+    verify(partialFailureAction, never()).accept(any());
+  }
+
+  @Test
   public void successfulAsListWithPredicate_allStagesSucceed_matchingResultsReturned() {
     final String result1 = "a";
     final String result2 = "b";
-    final List<CompletionStage<String>> input =
-        asList(completedFuture(result1), completedFuture(result2));
+    final List<CompletionStage<String>> input = asList(
+        completedFuture(result1),
+        completedFuture(result2)
+    );
 
     assertThat(successfulAsList(input, partialFailureAction, isEqual(result1)),
         completesTo(singletonList(result1)));
@@ -333,8 +349,21 @@ public class CompletableFuturesTest {
   @Test
   public void successfulAsListWithPredicate_allStagesSucceed_noMatchingResults() {
     final List<CompletionStage<String>> input = singletonList(completedFuture("a"));
+
     assertThat(successfulAsList(input, partialFailureAction, result -> false),
         completesTo(emptyList()));
+  }
+
+  @Test
+  public void successfulAsListWithPredicate_allStagesSucceed_partialFailureActionNotCalled() {
+    final List<CompletionStage<String>> input = asList(
+        completedFuture("a"),
+        completedFuture("b")
+    );
+
+    successfulAsList(input, partialFailureAction, result -> true).join();
+
+    verify(partialFailureAction, never()).accept(any());
   }
 
   @Test
@@ -357,19 +386,21 @@ public class CompletableFuturesTest {
   @Test
   public void successfulAsListWithPartialFailureAction_someStagesFail_successfulResultsReturned() {
     final String result = "a";
-    final List<CompletionStage<String>> input =
-        asList(completedFuture(result),
-            exceptionallyCompletedFuture(new RuntimeException()));
+    final List<CompletionStage<String>> input = asList(
+        completedFuture(result),
+        exceptionallyCompletedFuture(new RuntimeException())
+    );
 
-    assertThat(successfulAsList(input, partialFailureAction),
-        completesTo(singletonList(result)));
+    assertThat(successfulAsList(input, partialFailureAction), completesTo(singletonList(result)));
   }
 
   @Test
   public void successfulAsListWithPartialFailureAction_someStagesFail_partialFailureActionCalled() {
     final Throwable exception = new RuntimeException();
-    final List<CompletionStage<String>> input =
-        asList(completedFuture("a"), exceptionallyCompletedFuture(exception));
+    final List<CompletionStage<String>> input = asList(
+        completedFuture("a"),
+        exceptionallyCompletedFuture(exception)
+    );
 
     successfulAsList(input, partialFailureAction).join();
 
@@ -380,8 +411,10 @@ public class CompletableFuturesTest {
   public void successfulAsListWithPartialFailureAction_allStagesFail_exceptionReturned() {
     final Throwable exception1 = new RuntimeException("a");
     final Throwable exception2 = new RuntimeException("b");
-    final List<CompletionStage<String>> input =
-        asList(exceptionallyCompletedFuture(exception1), exceptionallyCompletedFuture(exception2));
+    final List<CompletionStage<String>> input = asList(
+        exceptionallyCompletedFuture(exception1),
+        exceptionallyCompletedFuture(exception2)
+    );
 
     final Throwable result = getException(successfulAsList(input, partialFailureAction));
 
@@ -391,9 +424,10 @@ public class CompletableFuturesTest {
 
   @Test
   public void successfulAsListWithPartialFailureAction_allStagesFail_partialFailureActionNotCalled() {
-    final List<CompletionStage<String>> input =
-        asList(exceptionallyCompletedFuture(new RuntimeException("a")),
-            exceptionallyCompletedFuture(new RuntimeException("b")));
+    final List<CompletionStage<String>> input = asList(
+        exceptionallyCompletedFuture(new RuntimeException("a")),
+        exceptionallyCompletedFuture(new RuntimeException("b"))
+    );
 
     try {
       successfulAsList(input, partialFailureAction).join();
@@ -407,9 +441,10 @@ public class CompletableFuturesTest {
   @Test
   public void successfulAsListWithPredicate_someStagesFail_matchingResultsReturned() {
     final String result = "a";
-    final List<CompletionStage<String>> input =
-        asList(completedFuture(result),
-            exceptionallyCompletedFuture(new RuntimeException()));
+    final List<CompletionStage<String>> input = asList(
+        completedFuture(result),
+        exceptionallyCompletedFuture(new RuntimeException())
+    );
 
     assertThat(successfulAsList(input, partialFailureAction, isEqual(result)),
         completesTo(singletonList(result)));
@@ -419,8 +454,10 @@ public class CompletableFuturesTest {
   public void successfulAsListWithPredicate_someStagesFailAndSomeMatchingResults_partialFailureActionCalled() {
     final String result = "a";
     final Throwable exception = new RuntimeException();
-    final List<CompletionStage<String>> input =
-        asList(completedFuture(result), exceptionallyCompletedFuture(exception));
+    final List<CompletionStage<String>> input = asList(
+        completedFuture(result),
+        exceptionallyCompletedFuture(exception)
+    );
 
     successfulAsList(input, partialFailureAction, isEqual(result)).join();
 
@@ -430,8 +467,10 @@ public class CompletableFuturesTest {
   @Test
   public void successfulAsListWithPredicate_someStagesFailAndNoMatchingResults_exceptionReturned() {
     final Throwable exception = new RuntimeException();
-    final List<CompletionStage<String>> input =
-        asList(completedFuture("a"), exceptionallyCompletedFuture(exception));
+    final List<CompletionStage<String>> input = asList(
+        completedFuture("a"),
+        exceptionallyCompletedFuture(exception)
+    );
 
     final Throwable result =
         getException(successfulAsList(input, partialFailureAction, successfulResult -> false));
@@ -442,11 +481,45 @@ public class CompletableFuturesTest {
 
   @Test
   public void successfulAsListWithPredicate_someStagesFailAndNoMatchingResults_partialFailureActionNotCalled() {
-    final List<CompletionStage<String>> input =
-        asList(completedFuture("a"), exceptionallyCompletedFuture(new RuntimeException()));
+    final List<CompletionStage<String>> input = asList(
+        completedFuture("a"),
+        exceptionallyCompletedFuture(new RuntimeException())
+    );
 
     try {
       successfulAsList(input, partialFailureAction, result -> false).join();
+    } catch (Exception e) {
+      // Ignore
+    }
+
+    verify(partialFailureAction, never()).accept(any());
+  }
+
+  @Test
+  public void successfulAsListWithPredicate_allStagesFail_exceptionReturned() {
+    final Throwable exception1 = new RuntimeException("a");
+    final Throwable exception2 = new RuntimeException("b");
+    final List<CompletionStage<String>> input = asList(
+        exceptionallyCompletedFuture(exception1),
+        exceptionallyCompletedFuture(exception2)
+    );
+
+    final Throwable result =
+        getException(successfulAsList(input, partialFailureAction, successfulResult -> true));
+
+    assertThat(result, is(instanceOf(StageFailureException.class)));
+    assertThat(result.getSuppressed(), is(arrayContaining(exception1, exception2)));
+  }
+
+  @Test
+  public void successfulAsListWithPredicate_allStagesFail_partialFailureActionNotCalled() {
+    final List<CompletionStage<String>> input = asList(
+        exceptionallyCompletedFuture(new RuntimeException("a")),
+        exceptionallyCompletedFuture(new RuntimeException("b"))
+    );
+
+    try {
+      successfulAsList(input, partialFailureAction, result -> true).join();
     } catch (Exception e) {
       // Ignore
     }

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -250,7 +250,7 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithDefaultValues_exceptionalAndNull() throws Exception {
+  public void successfulAsListWithDefaultValueMapper_exceptionalAndNull() throws Exception {
     final List<CompletableFuture<String>> input = asList(
         completedFuture("a"),
         exceptionallyCompletedFuture(new RuntimeException("boom")),
@@ -268,7 +268,7 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_null() {
+  public void successfulAsListWithPredicate_null() {
     exception.expect(NullPointerException.class);
     successfulAsList(null, partialFailureAction, result -> true);
   }
@@ -285,7 +285,7 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_containsNull() {
+  public void successfulAsListWithPredicate_containsNull() {
     final List<CompletionStage<String>> input = asList(
         completedFuture("a"),
         null
@@ -302,14 +302,14 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_empty() {
+  public void successfulAsListWithPredicate_empty() {
     final List<CompletionStage<String>> input = emptyList();
     assertThat(successfulAsList(input, partialFailureAction, result -> true),
         completesTo(emptyList()));
   }
 
   @Test
-  public void successfulAsListWithPartialFailureAction_successfulResults() {
+  public void successfulAsListWithPartialFailureAction_allStagesSucceed_successfulResultsReturned() {
     final String result1 = "a";
     final String result2 = "b";
     final List<CompletionStage<String>> input =
@@ -320,7 +320,7 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_matchingResults() {
+  public void successfulAsListWithPredicate_allStagesSucceed_matchingResultsReturned() {
     final String result1 = "a";
     final String result2 = "b";
     final List<CompletionStage<String>> input =
@@ -331,14 +331,14 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_noMatchingResults() {
+  public void successfulAsListWithPredicate_allStagesSucceed_noMatchingResults() {
     final List<CompletionStage<String>> input = singletonList(completedFuture("a"));
     assertThat(successfulAsList(input, partialFailureAction, result -> false),
         completesTo(emptyList()));
   }
 
   @Test
-  public void successfulAsListWithPartialFailureAction_notFailFast() {
+  public void successfulAsListWithPartialFailureAction_someStagesFail_notFailingFast() {
     final CompletableFuture<String> future1 = incompleteFuture();
     final CompletableFuture<String> future2 = incompleteFuture();
     final List<CompletionStage<String>> input = asList(future1, future2);
@@ -366,7 +366,7 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureAction_someStageFail_partialFailureActionCalled() {
+  public void successfulAsListWithPartialFailureAction_someStagesFail_partialFailureActionCalled() {
     final Throwable exception = new RuntimeException();
     final List<CompletionStage<String>> input =
         asList(completedFuture("a"), exceptionallyCompletedFuture(exception));
@@ -405,30 +405,30 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_someStagesFail_matchingResultsReturned() {
-    final String successfulResult = "a";
+  public void successfulAsListWithPredicate_someStagesFail_matchingResultsReturned() {
+    final String result = "a";
     final List<CompletionStage<String>> input =
-        asList(completedFuture(successfulResult),
+        asList(completedFuture(result),
             exceptionallyCompletedFuture(new RuntimeException()));
 
-    assertThat(successfulAsList(input, partialFailureAction, isEqual(successfulResult)),
-        completesTo(singletonList(successfulResult)));
+    assertThat(successfulAsList(input, partialFailureAction, isEqual(result)),
+        completesTo(singletonList(result)));
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_someStagesFailAndSomeMatchingResults_partialFailureActionCalled() {
-    final String successfulResult = "a";
+  public void successfulAsListWithPredicate_someStagesFailAndSomeMatchingResults_partialFailureActionCalled() {
+    final String result = "a";
     final Throwable exception = new RuntimeException();
     final List<CompletionStage<String>> input =
-        asList(completedFuture(successfulResult), exceptionallyCompletedFuture(exception));
+        asList(completedFuture(result), exceptionallyCompletedFuture(exception));
 
-    successfulAsList(input, partialFailureAction, isEqual(successfulResult)).join();
+    successfulAsList(input, partialFailureAction, isEqual(result)).join();
 
     verify(partialFailureAction).accept(singletonList(exception));
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_someStagesFailAndNoMatchingResults_exceptionReturned() {
+  public void successfulAsListWithPredicate_someStagesFailAndNoMatchingResults_exceptionReturned() {
     final Throwable exception = new RuntimeException();
     final List<CompletionStage<String>> input =
         asList(completedFuture("a"), exceptionallyCompletedFuture(exception));
@@ -441,12 +441,12 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureActionAndPredicate_someStagesFailAndNoMatchingResults_partialFailureActionNotCalled() {
+  public void successfulAsListWithPredicate_someStagesFailAndNoMatchingResults_partialFailureActionNotCalled() {
     final List<CompletionStage<String>> input =
         asList(completedFuture("a"), exceptionallyCompletedFuture(new RuntimeException()));
 
     try {
-      successfulAsList(input, partialFailureAction, successfulResult -> false).join();
+      successfulAsList(input, partialFailureAction, result -> false).join();
     } catch (Exception e) {
       // Ignore
     }

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -367,23 +367,6 @@ public class CompletableFuturesTest {
   }
 
   @Test
-  public void successfulAsListWithPartialFailureAction_someStagesFail_notFailingFast() {
-    final CompletableFuture<String> future1 = incompleteFuture();
-    final CompletableFuture<String> future2 = incompleteFuture();
-    final List<CompletionStage<String>> input = asList(future1, future2);
-
-    final CompletableFuture<List<String>> result = successfulAsList(input, partialFailureAction);
-
-    // We complete the futures manually to control the completion order and to verify that we wait
-    // for the second future to complete even if the first one fails. We wouldn't be able to do that
-    // if we used completed futures above.
-    future1.completeExceptionally(new RuntimeException());
-    final String successfulResult = "a";
-    future2.complete(successfulResult);
-    assertThat(result, completesTo(singletonList(successfulResult)));
-  }
-
-  @Test
   public void successfulAsListWithPartialFailureAction_someStagesFail_successfulResultsReturned() {
     final String result = "a";
     final List<CompletionStage<String>> input = asList(
@@ -405,6 +388,23 @@ public class CompletableFuturesTest {
     successfulAsList(input, partialFailureAction).join();
 
     verify(partialFailureAction).accept(singletonList(exception));
+  }
+
+  @Test
+  public void successfulAsListWithPartialFailureAction_someStagesFail_notFailingFast() {
+    final CompletableFuture<String> future1 = incompleteFuture();
+    final CompletableFuture<String> future2 = incompleteFuture();
+    final List<CompletionStage<String>> input = asList(future1, future2);
+
+    final CompletableFuture<List<String>> result = successfulAsList(input, partialFailureAction);
+
+    // We complete the futures manually to control the completion order and to verify that we wait
+    // for the second future to complete even if the first one fails. We wouldn't be able to do that
+    // if we used completed futures above.
+    future1.completeExceptionally(new RuntimeException());
+    final String successfulResult = "a";
+    future2.complete(successfulResult);
+    assertThat(result, completesTo(singletonList(successfulResult)));
   }
 
   @Test

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -356,13 +356,13 @@ public class CompletableFuturesTest {
 
   @Test
   public void successfulAsListWithPartialFailureAction_someStagesFail_successfulResultsReturned() {
-    final String successfulResult = "a";
+    final String result = "a";
     final List<CompletionStage<String>> input =
-        asList(completedFuture(successfulResult),
+        asList(completedFuture(result),
             exceptionallyCompletedFuture(new RuntimeException()));
 
     assertThat(successfulAsList(input, partialFailureAction),
-        completesTo(singletonList(successfulResult)));
+        completesTo(singletonList(result)));
   }
 
   @Test

--- a/src/test/java/com/spotify/futures/StageFailureExceptionTest.java
+++ b/src/test/java/com/spotify/futures/StageFailureExceptionTest.java
@@ -1,0 +1,41 @@
+/*-
+ * -\-\-
+ * completable-futures
+ * --
+ * Copyright (C) 2016 - 2021 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.futures;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class StageFailureExceptionTest {
+
+  @Test
+  public void exceptionsAreStoredAsSuppressedExceptions() {
+    Throwable exception1 = new RuntimeException("1");
+    Throwable exception2 = new RuntimeException("2");
+
+    StageFailureException stageFailureException =
+        new StageFailureException("message", Arrays.asList(exception1, exception2));
+
+    assertThat(stageFailureException.getSuppressed(), is(arrayContaining(exception1, exception2)));
+  }
+}

--- a/src/test/java/com/spotify/futures/StageFailureExceptionTest.java
+++ b/src/test/java/com/spotify/futures/StageFailureExceptionTest.java
@@ -19,11 +19,11 @@
  */
 package com.spotify.futures;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import org.junit.Test;
 
 public class StageFailureExceptionTest {
@@ -34,7 +34,7 @@ public class StageFailureExceptionTest {
     Throwable exception2 = new RuntimeException("2");
 
     StageFailureException stageFailureException =
-        new StageFailureException("message", Arrays.asList(exception1, exception2));
+        new StageFailureException("message", asList(exception1, exception2));
 
     assertThat(stageFailureException.getSuppressed(), is(arrayContaining(exception1, exception2)));
   }


### PR DESCRIPTION
This PR adds two `successfulAsList` methods:

**`successfulAsList` with partial failure action**
Returns the results of the stages that succeed. If some but not all stages fail, the exceptions of the failed stages will be passed to the provided partial failure action without affecting the joined future. This is useful when you want to get all successful results without being affected if some of the stages fail.

Example:
```java
List<CompletableFuture<String>> input = asList(
    completedFuture("a"),
    exceptionallyCompletedFuture(new RuntimeException("boom")));
CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(
    input,
    exceptions -> { System.err.println("Futures failed: " + exceptions); });
```

**`successfulAsList` with partial failure action and predicate**
Returns the results of the stages that succeed and that satisfy a predicate. If some stages fail and some successful results satisfy the predicate, the exceptions of the failed stages will be passed to the provided partial failure action without affecting the joined future. This is useful when you want to get all successful results, but ignore some of them and without being affected if some of the stages fail.

Example:
```java
List<CompletableFuture<String>> input = asList(
    completedFuture("a"),
    exceptionallyCompletedFuture(new RuntimeException("boom")));
CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(
    input,
    exceptions -> System.err.println("Futures failed: " + exceptions),
    value -> value.equals("a"));
```

One example use case is when retrieving multiple resources from an HTTP service. Assume that each resource is retrieved with a separate `CompletionStage`. When joining the stages, one might want to filter out missing resources, i.e. `404` responses, and make sure that they are ignored in the failure handling for the joined future. To achieve this, the `404` responses have to be filtered out before the stages are joined. That is implemented in this `successfulAsList` method.
