### PR TITLE
Add additional helper methods to wrap CompletableFutures.successfulAsList

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,11 @@ List<CompletableFuture<String>> input = asList(
 CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(input, t -> "default");
 ```
 
-There are also variants that accept a stream:
+There are also variants that accept a list of arguments and a function to turn them into CompletableFutures:
 ```java
-Stream<CompletableFuture<String>> input = asList(
-    completedFuture("a"),
-    exceptionallyCompletedFuture(new RuntimeException("boom"))).stream();
-CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(input, t -> "default");
+    List<Integer> input = asList(1, 2, 3, 4);
+    Function<Integer, CompletableFuture<String>> futureMapper = a -> completedFuture("" + a);
+    CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(input, futureMapper, (s, t) -> "default");
 ```
 
 and a map to allow passing other information about each future into the default object:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ List<CompletableFuture<String>> input = asList(
 CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(input, t -> "default");
 ```
 
+There are also variants that accept a stream:
+```java
+Stream<CompletableFuture<String>> input = asList(
+    completedFuture("a"),
+    exceptionallyCompletedFuture(new RuntimeException("boom"))).stream();
+CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(input, t -> "default");
+```
+
+and a map to allow passing other information about each future into the default object:
+```java
+Map<Integer, CompletableFuture<String>> input = asMap(
+    asList(1, 2),
+    asList(
+        completedFuture("a"),
+        exceptionallyCompletedFuture(new RuntimeException("boom"))));
+CompletableFuture<List<String>> joined = CompletableFutures.successfulAsList(input, (num, t) -> num + " default");
+```
+
 #### joinList
 
 `joinList` is a stream collector that combines multiple futures into a list. This is handy if you


### PR DESCRIPTION
This PR adds two helper functions to CompletableFutures

- One that takes a list of input and a transformer, to avoid the necessity of many developers writing variations of the below code, only to have the stream they just turned into a list, turned into a stream again.

```java
    CompletableFutures.successfulAsList(
        domainSpecificEntity.videoSource().stream()
            .map(
                video ->
                    originalFileLocationStore.insert(....))
            .toList(), // this bit
        e -> {
          LOG.error("failed to insert video for creator {}", domainSpecificEntity.spotifyUri(), e);
          return null;
        });
```


- One that allows the inclusion of a piece of data describing the CompletableFuture, allowing the possibility to create meaningful default objects from the input to a CompletableFuture list.

```java
    var creatorsFuture =
        CompletableFutures.successfulAsList(
            creatorUris.stream().map(creatorDataStore::getCreator).collect(Collectors.toList()),
            t -> {
              if (t instanceof CreatorNotFoundException) {
                return CreatorMetadata.newBuilder()
                    .setSpotifyUri(((CreatorNotFoundException) t).getUri())
                    .build();
              }
              return null; // here because it's not a known exception I lose the creator's info.
            });
```