### PR TITLE
Supply compose async

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ CompletionStage<CompletionStage<String>> wrapped = completedFuture(completedFutu
 CompletionStage<String> unwrapped = CompletableFutures.dereference(wrapped);
 ```
 
+#### supplyAsyncCompose
+
+Like `CompletableFuture.supplyAsync` but unwraps a `CompletionStage<CompletionStage<T>>` to a plain `CompletionStage<T>` when
+the `Supplier` returns a `CompletionStage`.
+
+```java
+CompletionStage<String> suppliedStage = completedFuture("hello").thenApply(stage -> stage + "-chained");
+CompletionStage<String> outputStage = CompletableFutures.supplyAsyncCompose(suppliedStage);
+```
+
 #### exceptionallyCompletedFuture
 
 Creates a new future that is already exceptionally completed with the given exception.

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,6 +34,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -43,8 +44,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 /**
- * A collection of static utility methods that extend the
- * {@link java.util.concurrent.CompletableFuture Java completable future} API.
+ * A collection of static utility methods that extend the {@link
+ * java.util.concurrent.CompletableFuture Java completable future} API.
  *
  * @since 0.1.0
  */
@@ -56,16 +57,16 @@ public final class CompletableFutures {
 
   /**
    * Returns a new {@link CompletableFuture} which completes to a list of all values of its input
-   * stages, if all succeed.  The list of results is in the same order as the input stages.
+   * stages, if all succeed. The list of results is in the same order as the input stages.
    *
-   * <p> As soon as any of the given stages complete exceptionally, then the returned future also does so,
-   * with a {@link CompletionException} holding this exception as its cause.
+   * <p>As soon as any of the given stages complete exceptionally, then the returned future also
+   * does so, with a {@link CompletionException} holding this exception as its cause.
    *
-   * <p> If no stages are provided, returns a future holding an empty list.
+   * <p>If no stages are provided, returns a future holding an empty list.
    *
    * @param stages the stages to combine
-   * @param <T>    the common super-type of all of the input stages, that determines the monomorphic
-   *               type of the output future
+   * @param <T> the common super-type of all of the input stages, that determines the monomorphic
+   *     type of the output future
    * @return a future that completes to a list of the results of the supplied stages
    * @throws NullPointerException if the stages list or any of its elements are {@code null}
    * @since 0.1.0
@@ -84,16 +85,17 @@ public final class CompletableFutures {
     CompletableFuture<Void> allOf = CompletableFuture.allOf(all);
 
     for (int i = 0; i < all.length; i++) {
-      all[i].exceptionally(throwable -> {
-        if (!allOf.isDone()) {
-          allOf.completeExceptionally(throwable);
-        }
-        return null; // intentionally unused
-      });
+      all[i].exceptionally(
+          throwable -> {
+            if (!allOf.isDone()) {
+              allOf.completeExceptionally(throwable);
+            }
+            return null; // intentionally unused
+          });
     }
 
-    return allOf
-        .thenApply(ignored -> {
+    return allOf.thenApply(
+        ignored -> {
           final List<T> result = new ArrayList<>(all.length);
           for (int i = 0; i < all.length; i++) {
             result.add(all[i].join());
@@ -106,15 +108,15 @@ public final class CompletableFutures {
    * Returns a new {@link CompletableFuture} which completes to a map of all values of its input
    * stages, if all succeed.
    *
-   * <p> If any of the given stages complete exceptionally, then the returned future also does so,
+   * <p>If any of the given stages complete exceptionally, then the returned future also does so,
    * with a {@link CompletionException} holding this exception as its cause.
    *
-   * <p> If no stages are provided, returns a future holding an empty map.
+   * <p>If no stages are provided, returns a future holding an empty map.
    *
    * @param map the map of stages to combine
-   * @param <U>    the common super-type of the keys
-   * @param <T>    the common super-type of all of the input value-stages, that determines the
-   *           monomorphic type of the output future
+   * @param <U> the common super-type of the keys
+   * @param <T> the common super-type of all of the input value-stages, that determines the
+   *     monomorphic type of the output future
    * @return a future that completes to a map of the results of the supplied keys and value-stages
    * @throws NullPointerException if value-stages or any of its elements are {@code null}
    * @since 0.3.3
@@ -149,28 +151,25 @@ public final class CompletableFutures {
    *
    * @param stages the stages to combine.
    * @param defaultValueMapper a function that will be called when a future completes exceptionally
-   * to provide a default value to place in the resulting list
-   * @param <T>    the common type of all of the input stages, that determines the type of the
-   *               output future
+   *     to provide a default value to place in the resulting list
+   * @param <T> the common type of all of the input stages, that determines the type of the output
+   *     future
    * @return a future that completes to a list of the results of the supplied stages
    * @throws NullPointerException if the stages list or any of its elements are {@code null}
    */
   public static <T> CompletableFuture<List<T>> successfulAsList(
       List<? extends CompletionStage<T>> stages,
       Function<Throwable, ? extends T> defaultValueMapper) {
-    return stages.stream()
-        .map(f -> f.exceptionally(defaultValueMapper))
-        .collect(joinList());
+    return stages.stream().map(f -> f.exceptionally(defaultValueMapper)).collect(joinList());
   }
 
   /**
-   * Returns a new {@code CompletableFuture} that is already exceptionally completed with
-   * the given exception.
+   * Returns a new {@code CompletableFuture} that is already exceptionally completed with the given
+   * exception.
    *
    * @param throwable the exception
-   * @param <T>       an arbitrary type for the returned future; can be anything since the future
-   *                  will be exceptionally completed and thus there will never be a value of type
-   *                  {@code T}
+   * @param <T> an arbitrary type for the returned future; can be anything since the future will be
+   *     exceptionally completed and thus there will never be a value of type {@code T}
    * @return a future that exceptionally completed with the supplied exception
    * @throws NullPointerException if the supplied throwable is {@code null}
    * @since 0.1.0
@@ -182,10 +181,10 @@ public final class CompletableFutures {
   }
 
   /**
-   * Collect a stream of {@link CompletionStage}s into a single future holding a list of the
-   * joined entities.
+   * Collect a stream of {@link CompletionStage}s into a single future holding a list of the joined
+   * entities.
    *
-   * <p> Usage:
+   * <p>Usage:
    *
    * <pre>{@code
    * collection.stream()
@@ -194,22 +193,22 @@ public final class CompletableFutures {
    *     .thenApply(this::consumeList)
    * }</pre>
    *
-   * <p> The generated {@link CompletableFuture} will complete to a list of all entities, in the
-   * order they were encountered in the original stream.  Similar to
-   * {@link CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures complete
-   * exceptionally, then the returned CompletableFuture also does so, with a
-   * {@link CompletionException} holding this exception as its cause.
+   * <p>The generated {@link CompletableFuture} will complete to a list of all entities, in the
+   * order they were encountered in the original stream. Similar to {@link
+   * CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures complete
+   * exceptionally, then the returned CompletableFuture also does so, with a {@link
+   * CompletionException} holding this exception as its cause.
    *
    * @param <T> the common super-type of all of the input stages, that determines the monomorphic
-   *            type of the output future
+   *     type of the output future
    * @param <S> the implementation of {@link CompletionStage} that the stream contains
    * @return a new {@link CompletableFuture} according to the rules outlined in the method
-   * description
+   *     description
    * @throws NullPointerException if any future in the stream is {@code null}
    * @since 0.1.0
    */
   public static <T, S extends CompletionStage<? extends T>>
-  Collector<S, ?, CompletableFuture<List<T>>> joinList() {
+      Collector<S, ?, CompletableFuture<List<T>>> joinList() {
     return collectingAndThen(toList(), CompletableFutures::allAsList);
   }
 
@@ -218,7 +217,7 @@ public final class CompletableFutures {
    * applying the provided mapping function to the input elements, and whose values are the
    * corresponding joined entities.
    *
-   * <p> Usage:
+   * <p>Usage:
    *
    * <pre>{@code
    * collection.stream()
@@ -226,27 +225,27 @@ public final class CompletableFutures {
    *     .thenApply(this::consumeMap)
    * }</pre>
    *
-   * <p> The generated {@link CompletableFuture} will complete to a Map of all entities. Similar
-   * to {@link CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures
-   * complete exceptionally, then the returned CompletableFuture also does so, with a
-   * {@link CompletionException} holding this exception as its cause.
+   * <p>The generated {@link CompletableFuture} will complete to a Map of all entities. Similar to
+   * {@link CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures complete
+   * exceptionally, then the returned CompletableFuture also does so, with a {@link
+   * CompletionException} holding this exception as its cause.
    *
    * @param keyMapper a mapping function to produce keys
-   * @param valueFutureMapper a mapping function to produce futures that will eventually produce
-   *                          the values
+   * @param valueFutureMapper a mapping function to produce futures that will eventually produce the
+   *     values
    * @param <T> the type of the input elements
    * @param <K> the output type of the key mapping function
    * @param <V> the common super-type of the stages returned by the value future mapping function
    * @return a new {@link CompletableFuture} according to the rules outlined in the method
-   * description
+   *     description
    * @throws NullPointerException if valueFutureMapper returns {@code null} for any input element
    * @since 0.3.4
    */
   public static <T, K, V> Collector<T, ?, CompletableFuture<Map<K, V>>> joinMap(
-          Function<? super T, ? extends K> keyMapper,
-          Function<? super T, ? extends CompletionStage<? extends V>> valueFutureMapper){
+      Function<? super T, ? extends K> keyMapper,
+      Function<? super T, ? extends CompletionStage<? extends V>> valueFutureMapper) {
     Collector<T, ?, Map<K, CompletionStage<? extends V>>> collector =
-            toMap(keyMapper, valueFutureMapper);
+        toMap(keyMapper, valueFutureMapper);
     return collectingAndThen(collector, CompletableFutures::allAsMap);
   }
 
@@ -267,7 +266,7 @@ public final class CompletableFutures {
    * Gets the value of a completed stage.
    *
    * @param stage a completed {@link CompletionStage}
-   * @param <T>   the type of the value that the stage completes into
+   * @param <T> the type of the value that the stage completes into
    * @return the value of the stage if it has one
    * @throws IllegalStateException if the stage is not completed
    * @since 0.1.0
@@ -280,13 +279,14 @@ public final class CompletableFutures {
 
   /**
    * Gets the exception from an exceptionally completed future
+   *
    * @param stage an exceptionally completed {@link CompletionStage}
-   * @param <T>   the type of the value that the stage completes into
+   * @param <T> the type of the value that the stage completes into
    * @return the exception the stage has completed with
    * @throws IllegalStateException if the stage is not completed exceptionally
    * @throws CancellationException if the stage was cancelled
-   * @throws UnsupportedOperationException if the {@link CompletionStage} does not
-   * support the {@link CompletionStage#toCompletableFuture()} operation
+   * @throws UnsupportedOperationException if the {@link CompletionStage} does not support the
+   *     {@link CompletionStage#toCompletableFuture()} operation
    */
   public static <T> Throwable getException(CompletionStage<T> stage) {
     CompletableFuture<T> future = stage.toCompletableFuture();
@@ -305,60 +305,88 @@ public final class CompletableFutures {
    * Returns a new stage that, when this stage completes either normally or exceptionally, is
    * executed with this stage's result and exception as arguments to the supplied function.
    *
-   * <p> When this stage is complete, the given function is invoked with the result (or {@code null}
+   * <p>When this stage is complete, the given function is invoked with the result (or {@code null}
    * if none) and the exception (or {@code null} if none) of this stage as arguments, and the
    * function's result is used to complete the returned stage.
    *
-   * <p> This differs from
-   * {@link java.util.concurrent.CompletionStage#handle(java.util.function.BiFunction)} in that the
+   * <p>This differs from {@link
+   * java.util.concurrent.CompletionStage#handle(java.util.function.BiFunction)} in that the
    * function should return a {@link java.util.concurrent.CompletionStage} rather than the value
    * directly.
    *
    * @param stage the {@link CompletionStage} to compose
-   * @param fn    the function to use to compute the value of the
-   *              returned {@link CompletionStage}
-   * @param <T>   the type of the input stage's value.
-   * @param <U>   the function's return type
+   * @param fn the function to use to compute the value of the returned {@link CompletionStage}
+   * @param <T> the type of the input stage's value.
+   * @param <U> the function's return type
    * @return the new {@link CompletionStage}
    * @since 0.1.0
    */
   public static <T, U> CompletionStage<U> handleCompose(
-      CompletionStage<T> stage,
-      BiFunction<? super T, Throwable, ? extends CompletionStage<U>> fn) {
+      CompletionStage<T> stage, BiFunction<? super T, Throwable, ? extends CompletionStage<U>> fn) {
     return dereference(stage.handle(fn));
   }
 
   /**
-   * Returns a new stage that, when this stage completes
-   * exceptionally, is executed with this stage's exception as the
-   * argument to the supplied function.  Otherwise, if this stage
-   * completes normally, then the returned stage also completes
-   * normally with the same value.
+   * Returns a new stage that, when this stage completes exceptionally, is executed with this
+   * stage's exception as the argument to the supplied function. Otherwise, if this stage completes
+   * normally, then the returned stage also completes normally with the same value.
    *
-   * <p>This differs from
-   * {@link java.util.concurrent.CompletionStage#exceptionally(java.util.function.Function)}
-   * in that the function should return a {@link java.util.concurrent.CompletionStage} rather than
-   * the value directly.
+   * <p>This differs from {@link
+   * java.util.concurrent.CompletionStage#exceptionally(java.util.function.Function)} in that the
+   * function should return a {@link java.util.concurrent.CompletionStage} rather than the value
+   * directly.
    *
    * @param stage the {@link CompletionStage} to compose
-   * @param fn    the function to use to compute the value of the
-   *              returned {@link CompletionStage} if this stage completed
-   *              exceptionally
-   * @param <T>   the type of the input stage's value.
+   * @param fn the function to use to compute the value of the returned {@link CompletionStage} if
+   *     this stage completed exceptionally
+   * @param <T> the type of the input stage's value.
    * @return the new {@link CompletionStage}
    * @since 0.1.0
    */
   public static <T> CompletionStage<T> exceptionallyCompose(
-      CompletionStage<T> stage,
-      Function<Throwable, ? extends CompletionStage<T>> fn) {
+      CompletionStage<T> stage, Function<Throwable, ? extends CompletionStage<T>> fn) {
     return dereference(wrap(stage).exceptionally(fn));
+  }
+
+  /**
+   * This allows for a stage to be the return type of supplier when using supplyAsync and returns a plain stage.
+   *
+   * <p>This differs from {@link
+   * java.util.concurrent.CompletableFuture#supplyAsync(Supplier)} in that the
+   * function should return a {@link java.util.concurrent.CompletionStage} rather than the {@link CompletionStage} of
+   * a {@link CompletionStage} of a value when the return value of the {@link Supplier} is a {@link CompletionStage}.
+   *
+   * @param supplier a {@link Supplier} with a return value of {@link CompletionStage}
+   * @param <U> the type of the supplied stage's value
+   * @return the new {@link CompletionStage}
+   */
+  public static <U> CompletionStage<U> supplyAsyncCompose(Supplier<CompletionStage<U>> supplier) {
+    return dereference(CompletableFuture.supplyAsync(supplier));
+  }
+
+  /**
+   * This allows for a stage to be the return type of supplier when using supplyAsync and returns a plain stage.
+   *
+   * <p>This differs from {@link
+   * java.util.concurrent.CompletableFuture#supplyAsync(Supplier, Executor)} in that the
+   * function should return a {@link java.util.concurrent.CompletionStage} rather than the {@link CompletionStage} of
+   * a {@link CompletionStage} of a value when the return value of the {@link Supplier} is a {@link CompletionStage}.
+   *
+   * @param supplier a {@link Supplier} with a return value of {@link CompletionStage}
+   * @param executor a {@link Executor} the executor to use for asynchronous execution
+   * @param <U> the type of the supplied stage's value
+   * @return the new {@link CompletionStage}
+   */
+  public static <U> CompletionStage<U> supplyAsyncCompose(
+      Supplier<CompletionStage<U>> supplier, Executor executor) {
+    return dereference(CompletableFuture.supplyAsync(supplier, executor));
   }
 
   /**
    * This takes a stage of a stage of a value and returns a plain stage of a value.
    *
    * @param stage a {@link CompletionStage} of a {@link CompletionStage} of a value
-   * @param <T>   the type of the inner stage's value.
+   * @param <T> the type of the inner stage's value.
    * @return the {@link CompletionStage} of the value
    * @since 0.1.0
    */
@@ -375,37 +403,38 @@ public final class CompletableFutures {
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
+   * @param a the first stage.
+   * @param b the second stage.
    * @param function the combining function.
-   * @param <R>      the type of the combining function's return value.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
+   * @param <R> the type of the combining function's return value.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.1.0
    */
   public static <R, A, B> CompletionStage<R> combine(
-      CompletionStage<A> a, CompletionStage<B> b,
-      BiFunction<A, B, R> function) {
+      CompletionStage<A> a, CompletionStage<B> b, BiFunction<A, B, R> function) {
     return a.thenCombine(b, function);
   }
 
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
-   * @param c        the third stage.
+   * @param a the first stage.
+   * @param b the second stage.
+   * @param c the third stage.
    * @param function the combining function.
-   * @param <R>      the type of the combining function's return value.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
-   * @param <C>      the type of the third stage's value.
+   * @param <R> the type of the combining function's return value.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
+   * @param <C> the type of the third stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.1.0
    */
   public static <R, A, B, C> CompletionStage<R> combine(
-      CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
+      CompletionStage<A> a,
+      CompletionStage<B> b,
+      CompletionStage<C> c,
       Function3<A, B, C, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
@@ -418,21 +447,24 @@ public final class CompletableFutures {
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
-   * @param c        the third stage.
-   * @param d        the fourth stage.
+   * @param a the first stage.
+   * @param b the second stage.
+   * @param c the third stage.
+   * @param d the fourth stage.
    * @param function the combining function.
-   * @param <R>      the type of the combining function's return value.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
-   * @param <C>      the type of the third stage's value.
-   * @param <D>      the type of the fourth stage's value.
+   * @param <R> the type of the combining function's return value.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
+   * @param <C> the type of the third stage's value.
+   * @param <D> the type of the fourth stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.1.0
    */
   public static <R, A, B, C, D> CompletionStage<R> combine(
-      CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c, CompletionStage<D> d,
+      CompletionStage<A> a,
+      CompletionStage<B> b,
+      CompletionStage<C> c,
+      CompletionStage<D> d,
       Function4<A, B, C, D, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
@@ -446,24 +478,27 @@ public final class CompletableFutures {
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
-   * @param c        the third stage.
-   * @param d        the fourth stage.
-   * @param e        the fifth stage.
+   * @param a the first stage.
+   * @param b the second stage.
+   * @param c the third stage.
+   * @param d the fourth stage.
+   * @param e the fifth stage.
    * @param function the combining function.
-   * @param <R>      the type of the combining function's return value.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
-   * @param <C>      the type of the third stage's value.
-   * @param <D>      the type of the fourth stage's value.
-   * @param <E>      the type of the fifth stage's value.
+   * @param <R> the type of the combining function's return value.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
+   * @param <C> the type of the third stage's value.
+   * @param <D> the type of the fourth stage's value.
+   * @param <E> the type of the fifth stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.1.0
    */
   public static <R, A, B, C, D, E> CompletionStage<R> combine(
-      CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
-      CompletionStage<D> d, CompletionStage<E> e,
+      CompletionStage<A> a,
+      CompletionStage<B> b,
+      CompletionStage<C> c,
+      CompletionStage<D> d,
+      CompletionStage<E> e,
       Function5<A, B, C, D, E, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
@@ -472,33 +507,37 @@ public final class CompletableFutures {
     final CompletableFuture<E> ef = e.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf, df, ef)
-        .thenApply(ignored ->
-                       function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join()));
+        .thenApply(
+            ignored -> function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join()));
   }
 
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
-   * @param c        the third stage.
-   * @param d        the fourth stage.
-   * @param e        the fifth stage.
-   * @param f        the sixth stage.
+   * @param a the first stage.
+   * @param b the second stage.
+   * @param c the third stage.
+   * @param d the fourth stage.
+   * @param e the fifth stage.
+   * @param f the sixth stage.
    * @param function the combining function.
-   * @param <R>      the type of the combining function's return value.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
-   * @param <C>      the type of the third stage's value.
-   * @param <D>      the type of the fourth stage's value.
-   * @param <E>      the type of the fifth stage's value.
-   * @param <F>      the type of the sixth stage's value.
+   * @param <R> the type of the combining function's return value.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
+   * @param <C> the type of the third stage's value.
+   * @param <D> the type of the fourth stage's value.
+   * @param <E> the type of the fifth stage's value.
+   * @param <F> the type of the sixth stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.3.2
    */
   public static <R, A, B, C, D, E, F> CompletionStage<R> combine(
-      CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
-      CompletionStage<D> d, CompletionStage<E> e, CompletionStage<F> f,
+      CompletionStage<A> a,
+      CompletionStage<B> b,
+      CompletionStage<C> c,
+      CompletionStage<D> d,
+      CompletionStage<E> e,
+      CompletionStage<F> f,
       Function6<A, B, C, D, E, F, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
@@ -508,26 +547,22 @@ public final class CompletableFutures {
     final CompletableFuture<F> ff = f.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf, df, ef, ff)
-        .thenApply(ignored ->
-                       function.apply(af.join(),
-                                      bf.join(),
-                                      cf.join(),
-                                      df.join(),
-                                      ef.join(),
-                                      ff.join()));
+        .thenApply(
+            ignored ->
+                function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join(), ff.join()));
   }
 
   /**
    * Combines multiple stages by applying a function.
    *
    * @param function the combining function.
-   * @param stages   the stages to combine
-   * @param <T>      the type of the combining function's return value.
+   * @param stages the stages to combine
+   * @param <T> the type of the combining function's return value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.4.0
    */
   public static <T> CompletionStage<T> combine(
-          Function<CombinedFutures, T> function, CompletionStage<?>... stages) {
+      Function<CombinedFutures, T> function, CompletionStage<?>... stages) {
     return combine(function, Arrays.asList(stages));
   }
 
@@ -535,38 +570,37 @@ public final class CompletableFutures {
    * Combines multiple stages by applying a function.
    *
    * @param function the combining function.
-   * @param stages   the stages to combine
-   * @param <T>      the type of the combining function's return value.
+   * @param stages the stages to combine
+   * @param <T> the type of the combining function's return value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.4.0
    */
   public static <T> CompletionStage<T> combine(
-          Function<CombinedFutures, T> function, List<? extends CompletionStage<?>> stages) {
+      Function<CombinedFutures, T> function, List<? extends CompletionStage<?>> stages) {
     @SuppressWarnings("unchecked") // generic array creation
     final CompletableFuture<?>[] all = new CompletableFuture[stages.size()];
     for (int i = 0; i < stages.size(); i++) {
       all[i] = stages.get(i).toCompletableFuture();
     }
-    return CompletableFuture.allOf(all).thenApply(ignored -> function.apply(new CombinedFutures(stages)));
+    return CompletableFuture.allOf(all)
+        .thenApply(ignored -> function.apply(new CombinedFutures(stages)));
   }
 
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
+   * @param a the first stage.
+   * @param b the second stage.
    * @param function the combining function.
-   * @param <R>      the type of the composed {@link CompletionStage}.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
+   * @param <R> the type of the composed {@link CompletionStage}.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
-   * do not interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
+   *     interoperate with CompletableFuture
    */
   public static <R, A, B> CompletionStage<R> combineFutures(
-      CompletionStage<A> a,
-      CompletionStage<B> b,
-      BiFunction<A, B, CompletionStage<R>> function) {
+      CompletionStage<A> a, CompletionStage<B> b, BiFunction<A, B, CompletionStage<R>> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
 
@@ -577,17 +611,17 @@ public final class CompletableFutures {
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
-   * @param c        the third stage.
+   * @param a the first stage.
+   * @param b the second stage.
+   * @param c the third stage.
    * @param function the combining function.
-   * @param <R>      the type of the composed {@link CompletionStage}.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
-   * @param <C>      the type of the third stage's value.
+   * @param <R> the type of the composed {@link CompletionStage}.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
+   * @param <C> the type of the third stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
-   * do not interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
+   *     interoperate with CompletableFuture
    */
   public static <R, A, B, C> CompletionStage<R> combineFutures(
       CompletionStage<A> a,
@@ -599,27 +633,25 @@ public final class CompletableFutures {
     final CompletableFuture<C> cf = c.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf)
-        .thenCompose(ignored -> function.apply(af.join(),
-                                               bf.join(),
-                                               cf.join()));
+        .thenCompose(ignored -> function.apply(af.join(), bf.join(), cf.join()));
   }
 
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
-   * @param c        the third stage.
-   * @param d        the fourth stage.
+   * @param a the first stage.
+   * @param b the second stage.
+   * @param c the third stage.
+   * @param d the fourth stage.
    * @param function the combining function.
-   * @param <R>      the type of the composed {@link CompletionStage}.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
-   * @param <C>      the type of the third stage's value.
-   * @param <D>      the type of the fourth stage's value.
+   * @param <R> the type of the composed {@link CompletionStage}.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
+   * @param <C> the type of the third stage's value.
+   * @param <D> the type of the fourth stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
-   * do not interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
+   *     interoperate with CompletableFuture
    */
   public static <R, A, B, C, D> CompletionStage<R> combineFutures(
       CompletionStage<A> a,
@@ -639,21 +671,21 @@ public final class CompletableFutures {
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
-   * @param c        the third stage.
-   * @param d        the fourth stage.
-   * @param e        the fifth stage.
+   * @param a the first stage.
+   * @param b the second stage.
+   * @param c the third stage.
+   * @param d the fourth stage.
+   * @param e the fifth stage.
    * @param function the combining function.
-   * @param <R>      the type of the composed {@link CompletionStage}.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
-   * @param <C>      the type of the third stage's value.
-   * @param <D>      the type of the fourth stage's value.
-   * @param <E>      the type of the fifth stage's value.
+   * @param <R> the type of the composed {@link CompletionStage}.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
+   * @param <C> the type of the third stage's value.
+   * @param <D> the type of the fourth stage's value.
+   * @param <E> the type of the fifth stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
-   * do not interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
+   *     interoperate with CompletableFuture
    */
   public static <R, A, B, C, D, E> CompletionStage<R> combineFutures(
       CompletionStage<A> a,
@@ -669,33 +701,30 @@ public final class CompletableFutures {
     final CompletableFuture<E> ef = e.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf, df, ef)
-        .thenCompose(ignored -> function.apply(af.join(),
-                                               bf.join(),
-                                               cf.join(),
-                                               df.join(),
-                                               ef.join()));
+        .thenCompose(
+            ignored -> function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join()));
   }
 
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a        the first stage.
-   * @param b        the second stage.
-   * @param c        the third stage.
-   * @param d        the fourth stage.
-   * @param e        the fifth stage.
-   * @param f        the sixth stage.
+   * @param a the first stage.
+   * @param b the second stage.
+   * @param c the third stage.
+   * @param d the fourth stage.
+   * @param e the fifth stage.
+   * @param f the sixth stage.
    * @param function the combining function.
-   * @param <R>      the type of the composed {@link CompletionStage}.
-   * @param <A>      the type of the first stage's value.
-   * @param <B>      the type of the second stage's value.
-   * @param <C>      the type of the third stage's value.
-   * @param <D>      the type of the fourth stage's value.
-   * @param <E>      the type of the fifth stage's value.
-   * @param <F>      the type of the sixth stage's value.
+   * @param <R> the type of the composed {@link CompletionStage}.
+   * @param <A> the type of the first stage's value.
+   * @param <B> the type of the second stage's value.
+   * @param <C> the type of the third stage's value.
+   * @param <D> the type of the fourth stage's value.
+   * @param <E> the type of the fifth stage's value.
+   * @param <F> the type of the sixth stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
-   * do not interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
+   *     interoperate with CompletableFuture
    */
   public static <R, A, B, C, D, E, F> CompletionStage<R> combineFutures(
       CompletionStage<A> a,
@@ -713,33 +742,30 @@ public final class CompletableFutures {
     final CompletableFuture<F> ff = f.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf, df, ef, ff)
-        .thenCompose(ignored -> function.apply(af.join(),
-                                               bf.join(),
-                                               cf.join(),
-                                               df.join(),
-                                               ef.join(),
-                                               ff.join()));
+        .thenCompose(
+            ignored ->
+                function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join(), ff.join()));
   }
 
   /**
    * Polls an external resource periodically until it returns a non-empty result.
    *
-   * <p> The polling task should return {@code Optional.empty()} until it becomes available, and
-   * then {@code Optional.of(result)}.  If the polling task throws an exception or returns null,
-   * that will cause the result future to complete exceptionally.
+   * <p>The polling task should return {@code Optional.empty()} until it becomes available, and then
+   * {@code Optional.of(result)}. If the polling task throws an exception or returns null, that will
+   * cause the result future to complete exceptionally.
    *
-   * <p> Canceling the returned future will cancel the scheduled polling task as well.
+   * <p>Canceling the returned future will cancel the scheduled polling task as well.
    *
-   * <p> Note that on a ScheduledThreadPoolExecutor the polling task might remain allocated for up
-   * to {@code frequency} time after completing or being cancelled.  If you have lots of polling
+   * <p>Note that on a ScheduledThreadPoolExecutor the polling task might remain allocated for up to
+   * {@code frequency} time after completing or being cancelled. If you have lots of polling
    * operations or a long polling frequency, consider setting {@code removeOnCancelPolicy} to true.
    * See {@link java.util.concurrent.ScheduledThreadPoolExecutor#setRemoveOnCancelPolicy(boolean)}.
    *
-   * @param pollingTask     the polling task
-   * @param frequency       the frequency to run the polling task at
+   * @param pollingTask the polling task
+   * @param frequency the frequency to run the polling task at
    * @param executorService the executor service to schedule the polling task on
-   * @param <T>             the type of the result of the polling task, that will be returned when
-   *                        the task succeeds.
+   * @param <T> the type of the result of the polling task, that will be returned when the task
+   *     succeeds.
    * @return a future completing to the result of the polling task once that becomes available
    */
   public static <T> CompletableFuture<T> poll(
@@ -747,20 +773,19 @@ public final class CompletableFutures {
       final Duration frequency,
       final ScheduledExecutorService executorService) {
     final CompletableFuture<T> result = new CompletableFuture<>();
-    final ScheduledFuture<?> scheduled = executorService.scheduleAtFixedRate(
-        () -> pollTask(pollingTask, result), 0, frequency.toMillis(), TimeUnit.MILLISECONDS);
+    final ScheduledFuture<?> scheduled =
+        executorService.scheduleAtFixedRate(
+            () -> pollTask(pollingTask, result), 0, frequency.toMillis(), TimeUnit.MILLISECONDS);
     result.whenComplete((r, ex) -> scheduled.cancel(true));
     return result;
   }
 
   private static <T> void pollTask(
-      final Supplier<Optional<T>> pollingTask,
-      final CompletableFuture<T> resultFuture) {
+      final Supplier<Optional<T>> pollingTask, final CompletableFuture<T> resultFuture) {
     try {
       pollingTask.get().ifPresent(resultFuture::complete);
     } catch (Exception ex) {
       resultFuture.completeExceptionally(ex);
     }
   }
-
 }

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,8 +44,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 /**
- * A collection of static utility methods that extend the {@link
- * java.util.concurrent.CompletableFuture Java completable future} API.
+ * A collection of static utility methods that extend the
+ * {@link java.util.concurrent.CompletableFuture Java completable future} API.
  *
  * @since 0.1.0
  */
@@ -57,16 +57,16 @@ public final class CompletableFutures {
 
   /**
    * Returns a new {@link CompletableFuture} which completes to a list of all values of its input
-   * stages, if all succeed. The list of results is in the same order as the input stages.
+   * stages, if all succeed.  The list of results is in the same order as the input stages.
    *
-   * <p>As soon as any of the given stages complete exceptionally, then the returned future also
-   * does so, with a {@link CompletionException} holding this exception as its cause.
+   * <p> As soon as any of the given stages complete exceptionally, then the returned future also does so,
+   * with a {@link CompletionException} holding this exception as its cause.
    *
-   * <p>If no stages are provided, returns a future holding an empty list.
+   * <p> If no stages are provided, returns a future holding an empty list.
    *
    * @param stages the stages to combine
-   * @param <T> the common super-type of all of the input stages, that determines the monomorphic
-   *     type of the output future
+   * @param <T>    the common super-type of all of the input stages, that determines the monomorphic
+   *               type of the output future
    * @return a future that completes to a list of the results of the supplied stages
    * @throws NullPointerException if the stages list or any of its elements are {@code null}
    * @since 0.1.0
@@ -85,17 +85,16 @@ public final class CompletableFutures {
     CompletableFuture<Void> allOf = CompletableFuture.allOf(all);
 
     for (int i = 0; i < all.length; i++) {
-      all[i].exceptionally(
-          throwable -> {
-            if (!allOf.isDone()) {
-              allOf.completeExceptionally(throwable);
-            }
-            return null; // intentionally unused
-          });
+      all[i].exceptionally(throwable -> {
+        if (!allOf.isDone()) {
+          allOf.completeExceptionally(throwable);
+        }
+        return null; // intentionally unused
+      });
     }
 
-    return allOf.thenApply(
-        ignored -> {
+    return allOf
+        .thenApply(ignored -> {
           final List<T> result = new ArrayList<>(all.length);
           for (int i = 0; i < all.length; i++) {
             result.add(all[i].join());
@@ -108,15 +107,15 @@ public final class CompletableFutures {
    * Returns a new {@link CompletableFuture} which completes to a map of all values of its input
    * stages, if all succeed.
    *
-   * <p>If any of the given stages complete exceptionally, then the returned future also does so,
+   * <p> If any of the given stages complete exceptionally, then the returned future also does so,
    * with a {@link CompletionException} holding this exception as its cause.
    *
-   * <p>If no stages are provided, returns a future holding an empty map.
+   * <p> If no stages are provided, returns a future holding an empty map.
    *
    * @param map the map of stages to combine
-   * @param <U> the common super-type of the keys
-   * @param <T> the common super-type of all of the input value-stages, that determines the
-   *     monomorphic type of the output future
+   * @param <U>    the common super-type of the keys
+   * @param <T>    the common super-type of all of the input value-stages, that determines the
+   *           monomorphic type of the output future
    * @return a future that completes to a map of the results of the supplied keys and value-stages
    * @throws NullPointerException if value-stages or any of its elements are {@code null}
    * @since 0.3.3
@@ -151,25 +150,28 @@ public final class CompletableFutures {
    *
    * @param stages the stages to combine.
    * @param defaultValueMapper a function that will be called when a future completes exceptionally
-   *     to provide a default value to place in the resulting list
-   * @param <T> the common type of all of the input stages, that determines the type of the output
-   *     future
+   * to provide a default value to place in the resulting list
+   * @param <T>    the common type of all of the input stages, that determines the type of the
+   *               output future
    * @return a future that completes to a list of the results of the supplied stages
    * @throws NullPointerException if the stages list or any of its elements are {@code null}
    */
   public static <T> CompletableFuture<List<T>> successfulAsList(
       List<? extends CompletionStage<T>> stages,
       Function<Throwable, ? extends T> defaultValueMapper) {
-    return stages.stream().map(f -> f.exceptionally(defaultValueMapper)).collect(joinList());
+    return stages.stream()
+        .map(f -> f.exceptionally(defaultValueMapper))
+        .collect(joinList());
   }
 
   /**
-   * Returns a new {@code CompletableFuture} that is already exceptionally completed with the given
-   * exception.
+   * Returns a new {@code CompletableFuture} that is already exceptionally completed with
+   * the given exception.
    *
    * @param throwable the exception
-   * @param <T> an arbitrary type for the returned future; can be anything since the future will be
-   *     exceptionally completed and thus there will never be a value of type {@code T}
+   * @param <T>       an arbitrary type for the returned future; can be anything since the future
+   *                  will be exceptionally completed and thus there will never be a value of type
+   *                  {@code T}
    * @return a future that exceptionally completed with the supplied exception
    * @throws NullPointerException if the supplied throwable is {@code null}
    * @since 0.1.0
@@ -181,10 +183,10 @@ public final class CompletableFutures {
   }
 
   /**
-   * Collect a stream of {@link CompletionStage}s into a single future holding a list of the joined
-   * entities.
+   * Collect a stream of {@link CompletionStage}s into a single future holding a list of the
+   * joined entities.
    *
-   * <p>Usage:
+   * <p> Usage:
    *
    * <pre>{@code
    * collection.stream()
@@ -193,22 +195,22 @@ public final class CompletableFutures {
    *     .thenApply(this::consumeList)
    * }</pre>
    *
-   * <p>The generated {@link CompletableFuture} will complete to a list of all entities, in the
-   * order they were encountered in the original stream. Similar to {@link
-   * CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures complete
-   * exceptionally, then the returned CompletableFuture also does so, with a {@link
-   * CompletionException} holding this exception as its cause.
+   * <p> The generated {@link CompletableFuture} will complete to a list of all entities, in the
+   * order they were encountered in the original stream.  Similar to
+   * {@link CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures complete
+   * exceptionally, then the returned CompletableFuture also does so, with a
+   * {@link CompletionException} holding this exception as its cause.
    *
    * @param <T> the common super-type of all of the input stages, that determines the monomorphic
-   *     type of the output future
+   *            type of the output future
    * @param <S> the implementation of {@link CompletionStage} that the stream contains
    * @return a new {@link CompletableFuture} according to the rules outlined in the method
-   *     description
+   * description
    * @throws NullPointerException if any future in the stream is {@code null}
    * @since 0.1.0
    */
   public static <T, S extends CompletionStage<? extends T>>
-      Collector<S, ?, CompletableFuture<List<T>>> joinList() {
+  Collector<S, ?, CompletableFuture<List<T>>> joinList() {
     return collectingAndThen(toList(), CompletableFutures::allAsList);
   }
 
@@ -217,7 +219,7 @@ public final class CompletableFutures {
    * applying the provided mapping function to the input elements, and whose values are the
    * corresponding joined entities.
    *
-   * <p>Usage:
+   * <p> Usage:
    *
    * <pre>{@code
    * collection.stream()
@@ -225,27 +227,27 @@ public final class CompletableFutures {
    *     .thenApply(this::consumeMap)
    * }</pre>
    *
-   * <p>The generated {@link CompletableFuture} will complete to a Map of all entities. Similar to
-   * {@link CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures complete
-   * exceptionally, then the returned CompletableFuture also does so, with a {@link
-   * CompletionException} holding this exception as its cause.
+   * <p> The generated {@link CompletableFuture} will complete to a Map of all entities. Similar
+   * to {@link CompletableFuture#allOf(CompletableFuture[])}, if any of the input futures
+   * complete exceptionally, then the returned CompletableFuture also does so, with a
+   * {@link CompletionException} holding this exception as its cause.
    *
    * @param keyMapper a mapping function to produce keys
-   * @param valueFutureMapper a mapping function to produce futures that will eventually produce the
-   *     values
+   * @param valueFutureMapper a mapping function to produce futures that will eventually produce
+   *                          the values
    * @param <T> the type of the input elements
    * @param <K> the output type of the key mapping function
    * @param <V> the common super-type of the stages returned by the value future mapping function
    * @return a new {@link CompletableFuture} according to the rules outlined in the method
-   *     description
+   * description
    * @throws NullPointerException if valueFutureMapper returns {@code null} for any input element
    * @since 0.3.4
    */
   public static <T, K, V> Collector<T, ?, CompletableFuture<Map<K, V>>> joinMap(
-      Function<? super T, ? extends K> keyMapper,
-      Function<? super T, ? extends CompletionStage<? extends V>> valueFutureMapper) {
+          Function<? super T, ? extends K> keyMapper,
+          Function<? super T, ? extends CompletionStage<? extends V>> valueFutureMapper){
     Collector<T, ?, Map<K, CompletionStage<? extends V>>> collector =
-        toMap(keyMapper, valueFutureMapper);
+            toMap(keyMapper, valueFutureMapper);
     return collectingAndThen(collector, CompletableFutures::allAsMap);
   }
 
@@ -266,7 +268,7 @@ public final class CompletableFutures {
    * Gets the value of a completed stage.
    *
    * @param stage a completed {@link CompletionStage}
-   * @param <T> the type of the value that the stage completes into
+   * @param <T>   the type of the value that the stage completes into
    * @return the value of the stage if it has one
    * @throws IllegalStateException if the stage is not completed
    * @since 0.1.0
@@ -279,14 +281,13 @@ public final class CompletableFutures {
 
   /**
    * Gets the exception from an exceptionally completed future
-   *
    * @param stage an exceptionally completed {@link CompletionStage}
-   * @param <T> the type of the value that the stage completes into
+   * @param <T>   the type of the value that the stage completes into
    * @return the exception the stage has completed with
    * @throws IllegalStateException if the stage is not completed exceptionally
    * @throws CancellationException if the stage was cancelled
-   * @throws UnsupportedOperationException if the {@link CompletionStage} does not support the
-   *     {@link CompletionStage#toCompletableFuture()} operation
+   * @throws UnsupportedOperationException if the {@link CompletionStage} does not
+   * support the {@link CompletionStage#toCompletableFuture()} operation
    */
   public static <T> Throwable getException(CompletionStage<T> stage) {
     CompletableFuture<T> future = stage.toCompletableFuture();
@@ -305,46 +306,52 @@ public final class CompletableFutures {
    * Returns a new stage that, when this stage completes either normally or exceptionally, is
    * executed with this stage's result and exception as arguments to the supplied function.
    *
-   * <p>When this stage is complete, the given function is invoked with the result (or {@code null}
+   * <p> When this stage is complete, the given function is invoked with the result (or {@code null}
    * if none) and the exception (or {@code null} if none) of this stage as arguments, and the
    * function's result is used to complete the returned stage.
    *
-   * <p>This differs from {@link
-   * java.util.concurrent.CompletionStage#handle(java.util.function.BiFunction)} in that the
+   * <p> This differs from
+   * {@link java.util.concurrent.CompletionStage#handle(java.util.function.BiFunction)} in that the
    * function should return a {@link java.util.concurrent.CompletionStage} rather than the value
    * directly.
    *
    * @param stage the {@link CompletionStage} to compose
-   * @param fn the function to use to compute the value of the returned {@link CompletionStage}
-   * @param <T> the type of the input stage's value.
-   * @param <U> the function's return type
+   * @param fn    the function to use to compute the value of the
+   *              returned {@link CompletionStage}
+   * @param <T>   the type of the input stage's value.
+   * @param <U>   the function's return type
    * @return the new {@link CompletionStage}
    * @since 0.1.0
    */
   public static <T, U> CompletionStage<U> handleCompose(
-      CompletionStage<T> stage, BiFunction<? super T, Throwable, ? extends CompletionStage<U>> fn) {
+      CompletionStage<T> stage,
+      BiFunction<? super T, Throwable, ? extends CompletionStage<U>> fn) {
     return dereference(stage.handle(fn));
   }
 
   /**
-   * Returns a new stage that, when this stage completes exceptionally, is executed with this
-   * stage's exception as the argument to the supplied function. Otherwise, if this stage completes
-   * normally, then the returned stage also completes normally with the same value.
+   * Returns a new stage that, when this stage completes
+   * exceptionally, is executed with this stage's exception as the
+   * argument to the supplied function.  Otherwise, if this stage
+   * completes normally, then the returned stage also completes
+   * normally with the same value.
    *
-   * <p>This differs from {@link
-   * java.util.concurrent.CompletionStage#exceptionally(java.util.function.Function)} in that the
-   * function should return a {@link java.util.concurrent.CompletionStage} rather than the value
-   * directly.
+   * <p>This differs from
+   * {@link java.util.concurrent.CompletionStage#exceptionally(java.util.function.Function)}
+   * in that the function should return a {@link java.util.concurrent.CompletionStage} rather than
+   * the value directly.
    *
    * @param stage the {@link CompletionStage} to compose
-   * @param fn the function to use to compute the value of the returned {@link CompletionStage} if
-   *     this stage completed exceptionally
-   * @param <T> the type of the input stage's value.
+   * @param fn    the function to use to compute the value of the
+   *              returned {@link CompletionStage} if this stage completed
+   *              exceptionally
+   * @param <T>   the type of the input stage's value.
    * @return the new {@link CompletionStage}
    * @since 0.1.0
    */
   public static <T> CompletionStage<T> exceptionallyCompose(
-      CompletionStage<T> stage, Function<Throwable, ? extends CompletionStage<T>> fn) {
+      CompletionStage<T> stage,
+      Function<Throwable, ? extends CompletionStage<T>> fn) {
     return dereference(wrap(stage).exceptionally(fn));
   }
 
@@ -378,7 +385,7 @@ public final class CompletableFutures {
    * @return the new {@link CompletionStage}
    */
   public static <U> CompletionStage<U> supplyAsyncCompose(
-      Supplier<CompletionStage<U>> supplier, Executor executor) {
+          Supplier<CompletionStage<U>> supplier, Executor executor) {
     return dereference(CompletableFuture.supplyAsync(supplier, executor));
   }
 
@@ -386,7 +393,7 @@ public final class CompletableFutures {
    * This takes a stage of a stage of a value and returns a plain stage of a value.
    *
    * @param stage a {@link CompletionStage} of a {@link CompletionStage} of a value
-   * @param <T> the type of the inner stage's value.
+   * @param <T>   the type of the inner stage's value.
    * @return the {@link CompletionStage} of the value
    * @since 0.1.0
    */
@@ -403,38 +410,37 @@ public final class CompletableFutures {
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
    * @param function the combining function.
-   * @param <R> the type of the combining function's return value.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
+   * @param <R>      the type of the combining function's return value.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.1.0
    */
   public static <R, A, B> CompletionStage<R> combine(
-      CompletionStage<A> a, CompletionStage<B> b, BiFunction<A, B, R> function) {
+      CompletionStage<A> a, CompletionStage<B> b,
+      BiFunction<A, B, R> function) {
     return a.thenCombine(b, function);
   }
 
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
-   * @param c the third stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
+   * @param c        the third stage.
    * @param function the combining function.
-   * @param <R> the type of the combining function's return value.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
-   * @param <C> the type of the third stage's value.
+   * @param <R>      the type of the combining function's return value.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
+   * @param <C>      the type of the third stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.1.0
    */
   public static <R, A, B, C> CompletionStage<R> combine(
-      CompletionStage<A> a,
-      CompletionStage<B> b,
-      CompletionStage<C> c,
+      CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
       Function3<A, B, C, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
@@ -447,24 +453,21 @@ public final class CompletableFutures {
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
-   * @param c the third stage.
-   * @param d the fourth stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
+   * @param c        the third stage.
+   * @param d        the fourth stage.
    * @param function the combining function.
-   * @param <R> the type of the combining function's return value.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
-   * @param <C> the type of the third stage's value.
-   * @param <D> the type of the fourth stage's value.
+   * @param <R>      the type of the combining function's return value.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
+   * @param <C>      the type of the third stage's value.
+   * @param <D>      the type of the fourth stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.1.0
    */
   public static <R, A, B, C, D> CompletionStage<R> combine(
-      CompletionStage<A> a,
-      CompletionStage<B> b,
-      CompletionStage<C> c,
-      CompletionStage<D> d,
+      CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c, CompletionStage<D> d,
       Function4<A, B, C, D, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
@@ -478,27 +481,24 @@ public final class CompletableFutures {
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
-   * @param c the third stage.
-   * @param d the fourth stage.
-   * @param e the fifth stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
+   * @param c        the third stage.
+   * @param d        the fourth stage.
+   * @param e        the fifth stage.
    * @param function the combining function.
-   * @param <R> the type of the combining function's return value.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
-   * @param <C> the type of the third stage's value.
-   * @param <D> the type of the fourth stage's value.
-   * @param <E> the type of the fifth stage's value.
+   * @param <R>      the type of the combining function's return value.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
+   * @param <C>      the type of the third stage's value.
+   * @param <D>      the type of the fourth stage's value.
+   * @param <E>      the type of the fifth stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.1.0
    */
   public static <R, A, B, C, D, E> CompletionStage<R> combine(
-      CompletionStage<A> a,
-      CompletionStage<B> b,
-      CompletionStage<C> c,
-      CompletionStage<D> d,
-      CompletionStage<E> e,
+      CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
+      CompletionStage<D> d, CompletionStage<E> e,
       Function5<A, B, C, D, E, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
@@ -507,37 +507,33 @@ public final class CompletableFutures {
     final CompletableFuture<E> ef = e.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf, df, ef)
-        .thenApply(
-            ignored -> function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join()));
+        .thenApply(ignored ->
+                       function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join()));
   }
 
   /**
    * Combines multiple stages by applying a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
-   * @param c the third stage.
-   * @param d the fourth stage.
-   * @param e the fifth stage.
-   * @param f the sixth stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
+   * @param c        the third stage.
+   * @param d        the fourth stage.
+   * @param e        the fifth stage.
+   * @param f        the sixth stage.
    * @param function the combining function.
-   * @param <R> the type of the combining function's return value.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
-   * @param <C> the type of the third stage's value.
-   * @param <D> the type of the fourth stage's value.
-   * @param <E> the type of the fifth stage's value.
-   * @param <F> the type of the sixth stage's value.
+   * @param <R>      the type of the combining function's return value.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
+   * @param <C>      the type of the third stage's value.
+   * @param <D>      the type of the fourth stage's value.
+   * @param <E>      the type of the fifth stage's value.
+   * @param <F>      the type of the sixth stage's value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.3.2
    */
   public static <R, A, B, C, D, E, F> CompletionStage<R> combine(
-      CompletionStage<A> a,
-      CompletionStage<B> b,
-      CompletionStage<C> c,
-      CompletionStage<D> d,
-      CompletionStage<E> e,
-      CompletionStage<F> f,
+      CompletionStage<A> a, CompletionStage<B> b, CompletionStage<C> c,
+      CompletionStage<D> d, CompletionStage<E> e, CompletionStage<F> f,
       Function6<A, B, C, D, E, F, R> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
@@ -547,22 +543,26 @@ public final class CompletableFutures {
     final CompletableFuture<F> ff = f.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf, df, ef, ff)
-        .thenApply(
-            ignored ->
-                function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join(), ff.join()));
+        .thenApply(ignored ->
+                       function.apply(af.join(),
+                                      bf.join(),
+                                      cf.join(),
+                                      df.join(),
+                                      ef.join(),
+                                      ff.join()));
   }
 
   /**
    * Combines multiple stages by applying a function.
    *
    * @param function the combining function.
-   * @param stages the stages to combine
-   * @param <T> the type of the combining function's return value.
+   * @param stages   the stages to combine
+   * @param <T>      the type of the combining function's return value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.4.0
    */
   public static <T> CompletionStage<T> combine(
-      Function<CombinedFutures, T> function, CompletionStage<?>... stages) {
+          Function<CombinedFutures, T> function, CompletionStage<?>... stages) {
     return combine(function, Arrays.asList(stages));
   }
 
@@ -570,37 +570,38 @@ public final class CompletableFutures {
    * Combines multiple stages by applying a function.
    *
    * @param function the combining function.
-   * @param stages the stages to combine
-   * @param <T> the type of the combining function's return value.
+   * @param stages   the stages to combine
+   * @param <T>      the type of the combining function's return value.
    * @return a stage that completes into the return value of the supplied function.
    * @since 0.4.0
    */
   public static <T> CompletionStage<T> combine(
-      Function<CombinedFutures, T> function, List<? extends CompletionStage<?>> stages) {
+          Function<CombinedFutures, T> function, List<? extends CompletionStage<?>> stages) {
     @SuppressWarnings("unchecked") // generic array creation
     final CompletableFuture<?>[] all = new CompletableFuture[stages.size()];
     for (int i = 0; i < stages.size(); i++) {
       all[i] = stages.get(i).toCompletableFuture();
     }
-    return CompletableFuture.allOf(all)
-        .thenApply(ignored -> function.apply(new CombinedFutures(stages)));
+    return CompletableFuture.allOf(all).thenApply(ignored -> function.apply(new CombinedFutures(stages)));
   }
 
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
    * @param function the combining function.
-   * @param <R> the type of the composed {@link CompletionStage}.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
+   * @param <R>      the type of the composed {@link CompletionStage}.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
-   *     interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
+   * do not interoperate with CompletableFuture
    */
   public static <R, A, B> CompletionStage<R> combineFutures(
-      CompletionStage<A> a, CompletionStage<B> b, BiFunction<A, B, CompletionStage<R>> function) {
+      CompletionStage<A> a,
+      CompletionStage<B> b,
+      BiFunction<A, B, CompletionStage<R>> function) {
     final CompletableFuture<A> af = a.toCompletableFuture();
     final CompletableFuture<B> bf = b.toCompletableFuture();
 
@@ -611,17 +612,17 @@ public final class CompletableFutures {
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
-   * @param c the third stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
+   * @param c        the third stage.
    * @param function the combining function.
-   * @param <R> the type of the composed {@link CompletionStage}.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
-   * @param <C> the type of the third stage's value.
+   * @param <R>      the type of the composed {@link CompletionStage}.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
+   * @param <C>      the type of the third stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
-   *     interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
+   * do not interoperate with CompletableFuture
    */
   public static <R, A, B, C> CompletionStage<R> combineFutures(
       CompletionStage<A> a,
@@ -633,25 +634,27 @@ public final class CompletableFutures {
     final CompletableFuture<C> cf = c.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf)
-        .thenCompose(ignored -> function.apply(af.join(), bf.join(), cf.join()));
+        .thenCompose(ignored -> function.apply(af.join(),
+                                               bf.join(),
+                                               cf.join()));
   }
 
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
-   * @param c the third stage.
-   * @param d the fourth stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
+   * @param c        the third stage.
+   * @param d        the fourth stage.
    * @param function the combining function.
-   * @param <R> the type of the composed {@link CompletionStage}.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
-   * @param <C> the type of the third stage's value.
-   * @param <D> the type of the fourth stage's value.
+   * @param <R>      the type of the composed {@link CompletionStage}.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
+   * @param <C>      the type of the third stage's value.
+   * @param <D>      the type of the fourth stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
-   *     interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
+   * do not interoperate with CompletableFuture
    */
   public static <R, A, B, C, D> CompletionStage<R> combineFutures(
       CompletionStage<A> a,
@@ -671,21 +674,21 @@ public final class CompletableFutures {
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
-   * @param c the third stage.
-   * @param d the fourth stage.
-   * @param e the fifth stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
+   * @param c        the third stage.
+   * @param d        the fourth stage.
+   * @param e        the fifth stage.
    * @param function the combining function.
-   * @param <R> the type of the composed {@link CompletionStage}.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
-   * @param <C> the type of the third stage's value.
-   * @param <D> the type of the fourth stage's value.
-   * @param <E> the type of the fifth stage's value.
+   * @param <R>      the type of the composed {@link CompletionStage}.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
+   * @param <C>      the type of the third stage's value.
+   * @param <D>      the type of the fourth stage's value.
+   * @param <E>      the type of the fifth stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
-   *     interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
+   * do not interoperate with CompletableFuture
    */
   public static <R, A, B, C, D, E> CompletionStage<R> combineFutures(
       CompletionStage<A> a,
@@ -701,30 +704,33 @@ public final class CompletableFutures {
     final CompletableFuture<E> ef = e.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf, df, ef)
-        .thenCompose(
-            ignored -> function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join()));
+        .thenCompose(ignored -> function.apply(af.join(),
+                                               bf.join(),
+                                               cf.join(),
+                                               df.join(),
+                                               ef.join()));
   }
 
   /**
    * Composes multiple stages into another stage using a function.
    *
-   * @param a the first stage.
-   * @param b the second stage.
-   * @param c the third stage.
-   * @param d the fourth stage.
-   * @param e the fifth stage.
-   * @param f the sixth stage.
+   * @param a        the first stage.
+   * @param b        the second stage.
+   * @param c        the third stage.
+   * @param d        the fourth stage.
+   * @param e        the fifth stage.
+   * @param f        the sixth stage.
    * @param function the combining function.
-   * @param <R> the type of the composed {@link CompletionStage}.
-   * @param <A> the type of the first stage's value.
-   * @param <B> the type of the second stage's value.
-   * @param <C> the type of the third stage's value.
-   * @param <D> the type of the fourth stage's value.
-   * @param <E> the type of the fifth stage's value.
-   * @param <F> the type of the sixth stage's value.
+   * @param <R>      the type of the composed {@link CompletionStage}.
+   * @param <A>      the type of the first stage's value.
+   * @param <B>      the type of the second stage's value.
+   * @param <C>      the type of the third stage's value.
+   * @param <D>      the type of the fourth stage's value.
+   * @param <E>      the type of the fifth stage's value.
+   * @param <F>      the type of the sixth stage's value.
    * @return a stage that is composed from the input stages using the function.
-   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s do not
-   *     interoperate with CompletableFuture
+   * @throws UnsupportedOperationException if any of the {@link CompletionStage}s
+   * do not interoperate with CompletableFuture
    */
   public static <R, A, B, C, D, E, F> CompletionStage<R> combineFutures(
       CompletionStage<A> a,
@@ -742,30 +748,33 @@ public final class CompletableFutures {
     final CompletableFuture<F> ff = f.toCompletableFuture();
 
     return CompletableFuture.allOf(af, bf, cf, df, ef, ff)
-        .thenCompose(
-            ignored ->
-                function.apply(af.join(), bf.join(), cf.join(), df.join(), ef.join(), ff.join()));
+        .thenCompose(ignored -> function.apply(af.join(),
+                                               bf.join(),
+                                               cf.join(),
+                                               df.join(),
+                                               ef.join(),
+                                               ff.join()));
   }
 
   /**
    * Polls an external resource periodically until it returns a non-empty result.
    *
-   * <p>The polling task should return {@code Optional.empty()} until it becomes available, and then
-   * {@code Optional.of(result)}. If the polling task throws an exception or returns null, that will
-   * cause the result future to complete exceptionally.
+   * <p> The polling task should return {@code Optional.empty()} until it becomes available, and
+   * then {@code Optional.of(result)}.  If the polling task throws an exception or returns null,
+   * that will cause the result future to complete exceptionally.
    *
-   * <p>Canceling the returned future will cancel the scheduled polling task as well.
+   * <p> Canceling the returned future will cancel the scheduled polling task as well.
    *
-   * <p>Note that on a ScheduledThreadPoolExecutor the polling task might remain allocated for up to
-   * {@code frequency} time after completing or being cancelled. If you have lots of polling
+   * <p> Note that on a ScheduledThreadPoolExecutor the polling task might remain allocated for up
+   * to {@code frequency} time after completing or being cancelled.  If you have lots of polling
    * operations or a long polling frequency, consider setting {@code removeOnCancelPolicy} to true.
    * See {@link java.util.concurrent.ScheduledThreadPoolExecutor#setRemoveOnCancelPolicy(boolean)}.
    *
-   * @param pollingTask the polling task
-   * @param frequency the frequency to run the polling task at
+   * @param pollingTask     the polling task
+   * @param frequency       the frequency to run the polling task at
    * @param executorService the executor service to schedule the polling task on
-   * @param <T> the type of the result of the polling task, that will be returned when the task
-   *     succeeds.
+   * @param <T>             the type of the result of the polling task, that will be returned when
+   *                        the task succeeds.
    * @return a future completing to the result of the polling task once that becomes available
    */
   public static <T> CompletableFuture<T> poll(
@@ -773,19 +782,20 @@ public final class CompletableFutures {
       final Duration frequency,
       final ScheduledExecutorService executorService) {
     final CompletableFuture<T> result = new CompletableFuture<>();
-    final ScheduledFuture<?> scheduled =
-        executorService.scheduleAtFixedRate(
-            () -> pollTask(pollingTask, result), 0, frequency.toMillis(), TimeUnit.MILLISECONDS);
+    final ScheduledFuture<?> scheduled = executorService.scheduleAtFixedRate(
+        () -> pollTask(pollingTask, result), 0, frequency.toMillis(), TimeUnit.MILLISECONDS);
     result.whenComplete((r, ex) -> scheduled.cancel(true));
     return result;
   }
 
   private static <T> void pollTask(
-      final Supplier<Optional<T>> pollingTask, final CompletableFuture<T> resultFuture) {
+      final Supplier<Optional<T>> pollingTask,
+      final CompletableFuture<T> resultFuture) {
     try {
       pollingTask.get().ifPresent(resultFuture::complete);
     } catch (Exception ex) {
       resultFuture.completeExceptionally(ex);
     }
   }
+
 }

--- a/src/main/java/com/spotify/futures/CompletableFutures.java
+++ b/src/main/java/com/spotify/futures/CompletableFutures.java
@@ -366,6 +366,7 @@ public final class CompletableFutures {
    * @param supplier a {@link Supplier} with a return value of {@link CompletionStage}
    * @param <U> the type of the supplied stage's value
    * @return the new {@link CompletionStage}
+   * @since 0.3.6
    */
   public static <U> CompletionStage<U> supplyAsyncCompose(Supplier<CompletionStage<U>> supplier) {
     return dereference(CompletableFuture.supplyAsync(supplier));
@@ -383,6 +384,7 @@ public final class CompletableFutures {
    * @param executor a {@link Executor} the executor to use for asynchronous execution
    * @param <U> the type of the supplied stage's value
    * @return the new {@link CompletionStage}
+   * @since 0.3.6
    */
   public static <U> CompletionStage<U> supplyAsyncCompose(
           Supplier<CompletionStage<U>> supplier, Executor executor) {

--- a/src/test/java/com/spotify/futures/CompletableFuturesTest.java
+++ b/src/test/java/com/spotify/futures/CompletableFuturesTest.java
@@ -515,6 +515,33 @@ public class CompletableFuturesTest {
   }
 
   @Test
+  public void supplyAsyncCompose_completed() {
+    final CompletionStage<String> future = completedFuture("hello");
+    final CompletionStage<String> composed = CompletableFutures.supplyAsyncCompose(() -> future);
+
+    assertThat(composed, completesTo("hello"));
+  }
+
+  @Test
+  public void supplyAsyncCompose_chain_completed() {
+    final CompletionStage<String> future = completedFuture("hello").thenApply(previous -> previous + "-chained");
+    final CompletionStage<String> composed = CompletableFutures.supplyAsyncCompose(() -> future);
+
+    assertThat(composed, completesTo("hello-chained"));
+  }
+
+  @Test
+  public void supplyAsyncCompose_failure() {
+    final IllegalStateException ex = new IllegalStateException();
+    final CompletionStage<String> future = exceptionallyCompletedFuture(ex);
+    final CompletionStage<String> composed = CompletableFutures.supplyAsyncCompose(() -> future);
+
+    final CompletionException e =
+            assertThrows(CompletionException.class, () -> getCompleted(composed));
+    assertThat(e.getCause(), is(equalTo(ex)));
+  }
+
+  @Test
   public void handleCompose_completed() {
     final CompletionStage<String> future = exceptionallyCompletedFuture(new Exception("boom"));
 


### PR DESCRIPTION
# Context

Adds a utility function `supplyAsyncCompose` which removes the need for dereferencing the output of `supplyAsync` whenever the `Supplier` return type is a `CompletionStage<T>` to avoid bloating of unwrapping the nested `CompletionStage<CompletionStage<T>>`.

This is beneficial when one would like to create Future chains on top of the Supplied type:
## Example
```java
// Before
// databaseOperation returns a CompletionStage
CompletableFuture.supplyAsync(() -> databaseOperation().thenApply(DataBaseRow::toProto)).thenCompose(result -> result);
```

```java
// After
// databaseOperation returns a CompletionStage
CompletableFuture.supplyAsyncCompose(() -> databaseOperation().thenApply(DataBaseRow::toProto));
```


**NOTES**
This might be achievable by wrapping every `supplyAsync` with the already existing `dereference` to get the same behaviour. This might be preferable, but if this seems valuable feel free to review and merge.